### PR TITLE
Implement REST and GraphQL sub-tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
+## Install the application
+
+```bash
+git clone git@github.com:maks-rafalko/nodejs-rss-task-graphql.git
+
+git checkout feature/graphql-implementation
+
+cd nodejs-rss-task-graphql
+
+# install dependencies
+npm ci
+```
+
+## Run the application
+
+In the development mode:
+
+```bash
+npm run dev
+```
+
+In the production mode:
+
+```bash
+npm run start
+```
+
+After both commands, server is listening on http://localhost:3000/.
+
+GraphQL is available on http://localhost:3000/graphql.
+
+## Test the application
+
+```bash
+npm run test
+```
+
+## Postman collection
+
+You can find Postman collection in the `./RSS GraphQL.postman_collection.json` file to simplify testing the application.
+
 ## Assignment: Graphql
 ### Tasks:
 1. Add logic to the restful endpoints (users, posts, profiles, member-types folders in ./src/routes).  

--- a/RSS GraphQL.postman_collection.json
+++ b/RSS GraphQL.postman_collection.json
@@ -1,0 +1,731 @@
+{
+	"info": {
+		"_postman_id": "ab590ce5-49e8-4d38-a674-1dc4a291dbe0",
+		"name": "RSS GraphQL",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "277379"
+	},
+	"item": [
+		{
+			"name": "POST /posts",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"title\": \"user 1 post\",\r\n    \"content\": \"content32\",\r\n    \"userId\": \"f898642b-1487-4c20-abf2-7346970851d1\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/posts",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"posts"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET /posts",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/posts",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"posts"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET /posts/:id",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/posts/8ce31daa-181c-4223-aded-427f904a92b3",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"posts",
+						"8ce31daa-181c-4223-aded-427f904a92b3"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST /users",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"firstName\": \"to f 2\",\r\n    \"lastName\": \"LN\",\r\n    \"email\": \"email@example.com\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/users",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET /users",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/users",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET /user/:id",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/users/bcb99cc0-5b6e-48ee-abef-d6d5b820878d",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"users",
+						"bcb99cc0-5b6e-48ee-abef-d6d5b820878d"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/users/:id/subscribeTo",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"userId\": \"cac73f79-475c-4957-a044-f27c1e9afd5a\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/users/c8011c39-c16d-4ee4-8a31-28e78991e987/subscribeTo",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"users",
+						"c8011c39-c16d-4ee4-8a31-28e78991e987",
+						"subscribeTo"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/users/:id/unsubscribeFrom",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"userId\": \"ca081bfe-5ac8-46e2-88d7-dfb48ca536fb\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/users/5f7603b3-5b83-4d8b-a5cb-99328876325b/unsubscribeFrom",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"users",
+						"5f7603b3-5b83-4d8b-a5cb-99328876325b",
+						"unsubscribeFrom"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/profiles",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"avatar\": \"avatar\",\r\n    \"sex\": \"male\",\r\n    \"birthday\": 29834345,\r\n    \"country\": \"USA\",\r\n    \"city\": \"New-York\",\r\n    \"street\": \"Street\",\r\n    \"memberTypeId\": \"basic\",\r\n    \"userId\": \"f898642b-1487-4c20-abf2-7346970851d1\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/profiles",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"profiles"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/member-types",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"userId\": \"\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/member-types",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"member-types"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.1 Get users, profiles, posts, memberTypes - 4 operations in one query.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query AllEntitiesIds {\r\n    users {id}\r\n    profiles {id}\r\n    posts {id}\r\n    memberTypes {id}\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.2. Get user, profile, post, memberType by id - 4 operations in one query.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query EntitiesById($userId: String!, $profileId: String!, $postId: String!, $memberTypeId: String!) {\r\n    user(id: $userId) {id}\r\n    profile(id: $profileId) {id}\r\n    post(id: $postId) {id}\r\n    memberType(id: $memberTypeId) {id}\r\n}",
+						"variables": "{\r\n    \"userId\": \"f898642b-1487-4c20-abf2-7346970851d1\",\r\n    \"profileId\": \"9e78f708-c424-4d8d-b444-9a5b04008612\",\r\n    \"postId\": \"aa483874-cd34-4cbb-b332-e2327f337fcb\",\r\n    \"memberTypeId\": \"basic\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.3 users with their posts, profiles, memberTypes",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UsersWithPostsProfilesMemberTypes {\r\n    users {\r\n        id\r\n        posts {\r\n            id\r\n        }\r\n        profile {\r\n            id\r\n        }\r\n        memberType {\r\n            id\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.4. Get user by id with his posts, profile, memberType",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UserByIdWithPostsProfileMemberType($id: String!) {\r\n    user(id: $id) {\r\n        id, \r\n        posts {\r\n            id\r\n        }\r\n        profile {\r\n            id\r\n        }\r\n        memberType {\r\n            id\r\n        }\r\n    }\r\n}",
+						"variables": "{\r\n    \"id\": \"992dda99-2c5f-46ca-aaf0-bce5dec54176\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.5. Get users with their userSubscribedTo, profile.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UserWithUsersHeIsFollowing {\r\n    users {\r\n        id\r\n        userSubscribedTo {\r\n            id\r\n        }\r\n        profile {\r\n            id\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.6 Get user by id with his subscribedToUser, posts.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UserByIdWithSubscribedUsersAndPosts($id: String!) {\r\n    user(id: $id) {\r\n        id, \r\n        subscribedToUser {id},\r\n        posts {id}\r\n    }\r\n}",
+						"variables": "{\r\n    \"id\": \"b10c5ad7-c0e7-4154-b6e8-553dec8860b6\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.7 Get users with their userSubscribedTo, subscribedToUser (additionally for each user in userSubscribedTo, subscribedToUser add their userSubscribedTo, subscribedToUser).",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UserWithNestedFollowersAdFollowingUsers {\r\n    users {\r\n        id\r\n        userSubscribedTo {\r\n            id,\r\n            userSubscribedTo {id}\r\n            subscribedToUser {id}\r\n        }\r\n        subscribedToUser  {\r\n            id\r\n            userSubscribedTo {id}\r\n            subscribedToUser {id}\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.8 createUser",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation CreateUser($user: UserCreateInput!) {\r\n    createUser(user: $user) {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n        subscribedToUserIds\r\n    }\r\n}",
+						"variables": "{\r\n    \"user\": {\r\n        \"firstName\": \"sdf\",\r\n        \"lastName\": \"LN\",\r\n        \"email\": \"email@example.com\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.9 createProfile",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation CreateProfile($profile: ProfileCreateInput!) {\r\n    createProfile(profile: $profile) {\r\n        id\r\n        avatar\r\n        sex\r\n        birthday\r\n        country\r\n        city\r\n        street\r\n        memberTypeId\r\n        userId\r\n    }\r\n}",
+						"variables": "{\r\n    \"profile\": {\r\n        \"avatar\": \"avatar\",\r\n        \"sex\": \"male\",\r\n        \"birthday\": 29834345,\r\n        \"country\": \"USA\",\r\n        \"city\": \"New-York\",\r\n        \"street\": \"Street\",\r\n        \"memberTypeId\": \"basic\",\r\n        \"userId\": \"0fae3a7b-0d04-4f0e-a71d-a78769854f96\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.10 createPost",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation CreatePost($post: PostCreateInput) {\r\n    createPost(post: $post) {\r\n        id\r\n        title\r\n        content\r\n        userId\r\n    }\r\n}",
+						"variables": "{\r\n    \"post\": {\r\n        \"title\": \"Title4\",\r\n        \"content\": \"content32\",\r\n        \"userId\": \"03490e0f-0414-4f4b-9883-0648956d9d49\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.12. Update user.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation UpdateUser($user: UserUpdateInput!, $userId: String!) {\r\n    updateUser(userId: $userId, user: $user) {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n        subscribedToUserIds\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"6fe4536e-b9a2-4162-879d-aa748c5b9850\",\r\n    \"user\": {\r\n        \"firstName\": \"1234\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.13. Update profile.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation UpdateProfile($profile: ProfileUpdateInput!, $profileId: String!) {\r\n    updateProfile(profileId: $profileId, profile: $profile) {\r\n        id\r\n        country\r\n    }\r\n}",
+						"variables": "{\r\n    \"profileId\": \"6b2872f2-ad4c-43bc-b98c-9506d92a35a9\",\r\n    \"profile\": {\r\n        \"country\": \"BY\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.14. Update post.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation UpdatePost($post: PostUpdateInput!, $postId: String!) {\r\n    updatePost(postId: $postId, post: $post) {\r\n        id\r\n        title\r\n        content\r\n        userId\r\n    }\r\n}",
+						"variables": "{\r\n    \"postId\": \"42589308-10d4-4094-a3e2-ce8cc4e021c4\",\r\n    \"post\": {\r\n        \"title\": \"BY fffff\",\r\n        \"content\": \"new content\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.15. Update memberType.",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation UpdateMemberType($memberType: MemberTypeUpdateInput!, $memberTypeId: String!) {\r\n    updateMemberType(memberTypeId: $memberTypeId, memberType: $memberType) {\r\n        id\r\n        discount\r\n        monthPostsLimit\r\n    }\r\n}",
+						"variables": "{\r\n    \"memberTypeId\": \"business\",\r\n    \"memberType\": {\r\n        \"discount\": 54\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.16. subscribeTo",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation UserSubscribeTo($payload: UserSubscribeToInput!) {\r\n    subscribeUserTo(payload: $payload) {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n        subscribedToUserIds\r\n        userSubscribedTo {id}\r\n    }\r\n}",
+						"variables": "{\r\n    \"payload\": {\r\n        \"currentUserId\": \"2f921ffb-0c46-4a53-b6d0-fd99afe5e2b5\",\r\n        \"subscribeToUserId\": \"78b7f48e-a704-4504-84fa-81f5f9108118\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 2.16. unsubscribeFrom",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation UnsubscribeUserFrom($payload: UserUnsubscribeFromInput!) {\r\n    unsubscribeUserFrom(payload: $payload) {\r\n        id,\r\n        firstName,\r\n        lastName,\r\n        email,\r\n        subscribedToUserIds,\r\n        userSubscribedTo {id}\r\n    }\r\n}",
+						"variables": "{\r\n    \"payload\": {\r\n        \"currentUserId\": \"44acec7c-b3a5-43e3-94d6-839eba2e3522\",\r\n        \"unsubscribeFromUserId\": \"8a4e7e34-f254-404b-9966-a20bb432ec65\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql 4 - depth-limit",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UserWithDepthOverflow {\r\n    users {\r\n        id\r\n        subscribedToUser {\r\n            userSubscribedTo {\r\n                subscribedToUser {\r\n                    userSubscribedTo {\r\n                        subscribedToUser {\r\n                            userSubscribedTo {\r\n                                id\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/graphql playground - random tests of queries",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query UsersWithPostsProfilesMemberTypes {\r\n    a: memberType(id: \"basic\") {id}\r\n    b: memberType(id: \"business\") {id}\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/routes/graphql/ContextValueType.ts
+++ b/src/routes/graphql/ContextValueType.ts
@@ -1,0 +1,9 @@
+import {FastifyInstance} from "fastify";
+import {Loaders} from "./Loaders";
+
+type ContextValueType = {
+  fastify: FastifyInstance;
+  loaders: Loaders
+}
+
+export { ContextValueType };

--- a/src/routes/graphql/ContextValueType.ts
+++ b/src/routes/graphql/ContextValueType.ts
@@ -1,5 +1,5 @@
-import {FastifyInstance} from "fastify";
-import {Loaders} from "./Loaders";
+import { FastifyInstance } from 'fastify';
+import { Loaders } from './Loaders';
 
 type ContextValueType = {
   fastify: FastifyInstance;

--- a/src/routes/graphql/Loaders.ts
+++ b/src/routes/graphql/Loaders.ts
@@ -1,8 +1,8 @@
-import * as DataLoader from "dataloader";
-import {UserEntity} from "../../utils/DB/entities/DBUsers";
-import {PostEntity} from "../../utils/DB/entities/DBPosts";
-import {ProfileEntity} from "../../utils/DB/entities/DBProfiles";
-import {MemberTypeEntity} from "../../utils/DB/entities/DBMemberTypes";
+import * as DataLoader from 'dataloader';
+import { UserEntity } from '../../utils/DB/entities/DBUsers';
+import { PostEntity } from '../../utils/DB/entities/DBPosts';
+import { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 
 type Loaders = {
   userById: DataLoader<string, UserEntity>;

--- a/src/routes/graphql/Loaders.ts
+++ b/src/routes/graphql/Loaders.ts
@@ -8,7 +8,9 @@ type Loaders = {
   userById: DataLoader<string, UserEntity>;
   usersBySubscribedToUserIds: DataLoader<string, UserEntity[]>;
   postsByUserId: DataLoader<string, PostEntity[]>;
+  postById: DataLoader<string, PostEntity>;
   profilesByUserId: DataLoader<string, ProfileEntity[]>;
+  profileById: DataLoader<string, ProfileEntity>;
   memberTypeById: DataLoader<string, MemberTypeEntity>;
   populateUserCache: (users: UserEntity[]) => void;
   populateMemberTypeCache: (memberTypes: MemberTypeEntity[]) => void;

--- a/src/routes/graphql/Loaders.ts
+++ b/src/routes/graphql/Loaders.ts
@@ -1,0 +1,17 @@
+import * as DataLoader from "dataloader";
+import {UserEntity} from "../../utils/DB/entities/DBUsers";
+import {PostEntity} from "../../utils/DB/entities/DBPosts";
+import {ProfileEntity} from "../../utils/DB/entities/DBProfiles";
+import {MemberTypeEntity} from "../../utils/DB/entities/DBMemberTypes";
+
+type Loaders = {
+  userById: DataLoader<string, UserEntity>;
+  usersBySubscribedToUserIds: DataLoader<string, UserEntity[]>;
+  postsByUserId: DataLoader<string, PostEntity[]>;
+  profilesByUserId: DataLoader<string, ProfileEntity[]>;
+  memberTypeById: DataLoader<string, MemberTypeEntity>;
+  populateUserCache: (users: UserEntity[]) => void;
+  populateMemberTypeCache: (memberTypes: MemberTypeEntity[]) => void;
+}
+
+export { Loaders };

--- a/src/routes/graphql/createDataLoaders.ts
+++ b/src/routes/graphql/createDataLoaders.ts
@@ -1,0 +1,89 @@
+import { FastifyInstance } from 'fastify';
+import { Loaders } from './Loaders';
+import * as DataLoader from 'dataloader';
+import { PostEntity } from '../../utils/DB/entities/DBPosts';
+import * as lodash from 'lodash';
+import { UserEntity } from '../../utils/DB/entities/DBUsers';
+import { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
+
+const createDataLoaders = (fastify: FastifyInstance): Loaders => {
+  const postsByUserId = new DataLoader<string, PostEntity[]>(async (userIds: readonly string[]): Promise<PostEntity[][]> => {
+    const posts = await fastify.db.posts.findMany({key: 'userId', equalsAnyOf: userIds as string[]});
+
+    const groupedByUserId = lodash.groupBy(posts, 'userId');
+
+    return userIds.map(userId => groupedByUserId[userId] ?? []);
+  });
+
+  const userById = new DataLoader<string, UserEntity>(async (userIds: readonly string[]): Promise<UserEntity[]> => {
+    const users = await fastify.db.users.findMany({key: 'id', equalsAnyOf: userIds as string[]});
+
+    const usersById: Record<string, UserEntity> = {};
+
+    for (const user of users) {
+      usersById[user.id] = user;
+    }
+
+    return userIds.map(userId => usersById[userId] ?? null);
+  });
+
+  const usersBySubscribedToUserIds = new DataLoader<string, UserEntity[]>(async (userIds: readonly string[]): Promise<UserEntity[][]> => {
+    const users = await fastify.db.users.findMany({key: 'subscribedToUserIds', inArrayAnyOf: userIds as string[]});
+
+    const usersBySubscribedToUserIds: Record<string, UserEntity[]> = {};
+
+    for (const userId of userIds) {
+      for (const user of users) {
+        if (user.subscribedToUserIds.includes(userId)) {
+          if (!usersBySubscribedToUserIds.hasOwnProperty(userId)) {
+            usersBySubscribedToUserIds[userId] = [];
+          }
+          usersBySubscribedToUserIds[userId] = [user, ...usersBySubscribedToUserIds[userId]];
+        }
+      }
+    }
+
+    return userIds.map(userId => usersBySubscribedToUserIds[userId] ?? []);
+  });
+
+  const profilesByUserId = new DataLoader<string, ProfileEntity[]>(async (userIds: readonly string[]): Promise<ProfileEntity[][]> => {
+    const profiles = await fastify.db.profiles.findMany({key: 'userId', equalsAnyOf: userIds as string[]});
+
+    const groupedByUserId = lodash.groupBy(profiles, 'userId');
+
+    return userIds.map(userId => groupedByUserId[userId] ?? []);
+  });
+
+  const memberTypeById = new DataLoader<string, MemberTypeEntity>(async (memberTypeIds: readonly string[]): Promise<MemberTypeEntity[]> => {
+    const memberTypes: MemberTypeEntity[] = await fastify.db.memberTypes.findMany({key: 'id', equalsAnyOf: memberTypeIds as string[]});
+
+    const memberTypesById: Record<string, MemberTypeEntity> = {};
+
+    for (const memberType of memberTypes) {
+      memberTypesById[memberType.id] = memberType;
+    }
+
+    return memberTypeIds.map(memberTypeId => memberTypesById[memberTypeId] ?? null);
+  });
+
+  return {
+    userById,
+    usersBySubscribedToUserIds,
+    postsByUserId,
+    profilesByUserId,
+    memberTypeById,
+    populateUserCache: (users: UserEntity[]): void => {
+      for (const user of users) {
+        userById.prime(user.id, user);
+      }
+    },
+    populateMemberTypeCache: (memberTypes: MemberTypeEntity[]): void => {
+      for (const memberType of memberTypes) {
+        memberTypeById.prime(memberType.id, memberType);
+      }
+    }
+  }
+}
+
+export { createDataLoaders };

--- a/src/routes/graphql/createDataLoaders.ts
+++ b/src/routes/graphql/createDataLoaders.ts
@@ -16,6 +16,18 @@ const createDataLoaders = (fastify: FastifyInstance): Loaders => {
     return userIds.map(userId => groupedByUserId[userId] ?? []);
   });
 
+  const postById = new DataLoader<string, PostEntity>(async (postIds: readonly string[]): Promise<PostEntity[]> => {
+    const posts = await fastify.db.posts.findMany({key: 'id', equalsAnyOf: postIds as string[]});
+
+    const postsById: Record<string, PostEntity> = {};
+
+    for (const post of posts) {
+      postsById[post.id] = post;
+    }
+
+    return postIds.map(postId => postsById[postId] ?? null);
+  });
+
   const userById = new DataLoader<string, UserEntity>(async (userIds: readonly string[]): Promise<UserEntity[]> => {
     const users = await fastify.db.users.findMany({key: 'id', equalsAnyOf: userIds as string[]});
 
@@ -55,6 +67,18 @@ const createDataLoaders = (fastify: FastifyInstance): Loaders => {
     return userIds.map(userId => groupedByUserId[userId] ?? []);
   });
 
+  const profileById = new DataLoader<string, ProfileEntity>(async (profileIds: readonly string[]): Promise<ProfileEntity[]> => {
+    const profiles: ProfileEntity[] = await fastify.db.profiles.findMany({key: 'id', equalsAnyOf: profileIds as string[]});
+
+    const profilesById: Record<string, ProfileEntity> = {};
+
+    for (const profile of profiles) {
+      profilesById[profile.id] = profile;
+    }
+
+    return profileIds.map(profileId => profilesById[profileId] ?? null);
+  });
+
   const memberTypeById = new DataLoader<string, MemberTypeEntity>(async (memberTypeIds: readonly string[]): Promise<MemberTypeEntity[]> => {
     const memberTypes: MemberTypeEntity[] = await fastify.db.memberTypes.findMany({key: 'id', equalsAnyOf: memberTypeIds as string[]});
 
@@ -71,7 +95,9 @@ const createDataLoaders = (fastify: FastifyInstance): Loaders => {
     userById,
     usersBySubscribedToUserIds,
     postsByUserId,
+    postById,
     profilesByUserId,
+    profileById,
     memberTypeById,
     populateUserCache: (users: UserEntity[]): void => {
       for (const user of users) {

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -25,23 +25,21 @@ import { updateMemberTypeQuery } from './memberType/updateMemberTypeQuery';
 import { subscribeUserToQuery } from './user/subscribeUserToQuery';
 import { unsubscribeUserFromQuery } from './user/unsubscribeUserFromQuery';
 import * as depthLimit from 'graphql-depth-limit';
-import {FastifyInstance} from "fastify";
-import {GraphQLError} from "graphql/error/GraphQLError";
+import { FastifyInstance } from 'fastify';
+import { GraphQLError } from 'graphql/error/GraphQLError';
 import * as DataLoader from "dataloader";
-import {PostEntity} from "../../utils/DB/entities/DBPosts";
+import { PostEntity } from '../../utils/DB/entities/DBPosts';
 import * as lodash from 'lodash';
-import {UserEntity} from "../../utils/DB/entities/DBUsers";
-import {ProfileEntity} from "../../utils/DB/entities/DBProfiles";
-import {Loaders} from "./Loaders";
-import {MemberTypeEntity} from "../../utils/DB/entities/DBMemberTypes";
+import { UserEntity } from '../../utils/DB/entities/DBUsers';
+import { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import { Loaders } from './Loaders';
+import { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 
 const GRAPHQL_QUERY_DEPTH_LIMIT = 6;
 
-// tODO check REST patch schemas and allow the only same fields in graphql!
+// todo bug with setting null
+// todo validate uuid by graphql
 // todo in graphql, do not use http errors
-// todo check all methods use variables instead of hardcoded values
-// todo check in some playground - whether there are any warnings / errors
-// todo remove commas (,) from all requests
 // todo add postman collection
 
 const querySchema = new GraphQLObjectType({

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -11,7 +11,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+        // const { query, variables } = request.body;
+        //
+        // const result = await this.graphql(query, variables);
+    }
   );
 };
 

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -5,14 +5,18 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
 } from 'graphql';
-import {userQuery} from './user/userQuery';
-import {usersQuery} from "./user/usersQuery";
-import {profileQuery} from "./profile/profileQuery";
-import {profilesQuery} from "./profile/profilesQuery";
-import {postQuery} from "./post/postQuery";
-import {postsQuery} from "./post/postsQuery";
-import {memberTypeQuery} from "./memberType/memberTypeQuery";
-import {memberTypesQuery} from "./memberType/memberTypesQuery";
+import { userQuery } from './user/userQuery';
+import { usersQuery } from './user/usersQuery';
+import { profileQuery } from './profile/profileQuery';
+import { profilesQuery } from './profile/profilesQuery';
+import { postQuery } from './post/postQuery';
+import { postsQuery } from './post/postsQuery';
+import { memberTypeQuery } from './memberType/memberTypeQuery';
+import { memberTypesQuery } from './memberType/memberTypesQuery';
+import { createUserQuery } from './user/createUserQuery';
+import { createProfileQuery } from './profile/createProfileQuery';
+import {createPostQuery} from "./post/createPostQuery";
+import {updateUserQuery} from "./user/updateUserQuery";
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -31,8 +35,21 @@ const querySchema = new GraphQLObjectType({
   }
 });
 
+// todo add new GraphQLNonNull()
+const mutationSchema = new GraphQLObjectType({
+  name: 'Mutation',
+  fields: {
+    createUser: createUserQuery,
+    updateUser: updateUserQuery,
+
+    createProfile: createProfileQuery,
+    createPost: createPostQuery,
+  }
+});
+
 const schema = new GraphQLSchema({
-  query: querySchema
+  query: querySchema,
+  mutation: mutationSchema,
 });
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -2,10 +2,8 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { graphqlBodySchema } from './schema';
 import {
   graphql,
-  validate,
-  parse,
   GraphQLSchema,
-  GraphQLObjectType, DocumentNode, Source,
+  GraphQLObjectType,
 } from 'graphql';
 import { userQuery } from './user/userQuery';
 import { usersQuery } from './user/usersQuery';
@@ -24,18 +22,8 @@ import { updatePostQuery } from './post/updatePostQuery';
 import { updateMemberTypeQuery } from './memberType/updateMemberTypeQuery';
 import { subscribeUserToQuery } from './user/subscribeUserToQuery';
 import { unsubscribeUserFromQuery } from './user/unsubscribeUserFromQuery';
-import * as depthLimit from 'graphql-depth-limit';
-import { FastifyInstance } from 'fastify';
-import { GraphQLError } from 'graphql/error/GraphQLError';
-import * as DataLoader from "dataloader";
-import { PostEntity } from '../../utils/DB/entities/DBPosts';
-import * as lodash from 'lodash';
-import { UserEntity } from '../../utils/DB/entities/DBUsers';
-import { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
-import { Loaders } from './Loaders';
-import { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
-
-const GRAPHQL_QUERY_DEPTH_LIMIT = 6;
+import { createDataLoaders } from './createDataLoaders';
+import { validateQuery } from './validateQuery';
 
 // todo bug with setting null
 // todo validate uuid by graphql
@@ -97,7 +85,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const queryAsString = String(query);
 
       // @ts-ignore
-      const validationErrors = validateQuery(queryAsString, fastify);
+      const validationErrors = validateQuery(schema, queryAsString, fastify);
 
       if (validationErrors.length > 0) {
         reply.send({data: null, errors: validationErrors});
@@ -105,7 +93,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       }
 
       // @ts-ignore
-      const loaders = createLoaders(fastify);
+      const loaders = createDataLoaders(fastify);
 
       return await graphql({
         schema,
@@ -119,101 +107,5 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     }
   );
 };
-
-function validateQuery(queryAsString: string, fastify: FastifyInstance): ReadonlyArray<GraphQLError> {
-  let documentAST: DocumentNode;
-
-  try {
-    documentAST = parse(new Source(queryAsString, 'GraphQL request'));
-  } catch (syntaxError: any) {
-    // Return 400: Bad Request if any syntax errors exist.
-    throw fastify.httpErrors.badRequest(syntaxError.message);
-  }
-
-  const validationErrors = validate(schema, documentAST, [
-    depthLimit(GRAPHQL_QUERY_DEPTH_LIMIT)
-  ]);
-
-  return validationErrors;
-}
-
-function createLoaders(fastify: FastifyInstance): Loaders {
-  const postsByUserId = new DataLoader<string, PostEntity[]>(async (userIds: readonly string[]): Promise<PostEntity[][]> => {
-    const posts = await fastify.db.posts.findMany({key: 'userId', equalsAnyOf: userIds as string[]});
-
-    const groupedByUserId = lodash.groupBy(posts, 'userId');
-
-    return userIds.map(userId => groupedByUserId[userId] ?? []);
-  });
-
-  const userById = new DataLoader<string, UserEntity>(async (userIds: readonly string[]): Promise<UserEntity[]> => {
-    const users = await fastify.db.users.findMany({key: 'id', equalsAnyOf: userIds as string[]});
-
-    const usersById: Record<string, UserEntity> = {};
-
-    for (const user of users) {
-      usersById[user.id] = user;
-    }
-
-    return userIds.map(userId => usersById[userId] ?? null);
-  });
-
-  const usersBySubscribedToUserIds = new DataLoader<string, UserEntity[]>(async (userIds: readonly string[]): Promise<UserEntity[][]> => {
-    const users = await fastify.db.users.findMany({key: 'subscribedToUserIds', inArrayAnyOf: userIds as string[]});
-
-    const usersBySubscribedToUserIds: Record<string, UserEntity[]> = {};
-
-    for (const userId of userIds) {
-      for (const user of users) {
-        if (user.subscribedToUserIds.includes(userId)) {
-          if (!usersBySubscribedToUserIds.hasOwnProperty(userId)) {
-            usersBySubscribedToUserIds[userId] = [];
-          }
-          usersBySubscribedToUserIds[userId] = [user, ...usersBySubscribedToUserIds[userId]];
-        }
-      }
-    }
-
-    return userIds.map(userId => usersBySubscribedToUserIds[userId] ?? []);
-  });
-
-  const profilesByUserId = new DataLoader<string, ProfileEntity[]>(async (userIds: readonly string[]): Promise<ProfileEntity[][]> => {
-    const profiles = await fastify.db.profiles.findMany({key: 'userId', equalsAnyOf: userIds as string[]});
-
-    const groupedByUserId = lodash.groupBy(profiles, 'userId');
-
-    return userIds.map(userId => groupedByUserId[userId] ?? []);
-  });
-
-  const memberTypeById = new DataLoader<string, MemberTypeEntity>(async (memberTypeIds: readonly string[]): Promise<MemberTypeEntity[]> => {
-    const memberTypes: MemberTypeEntity[] = await fastify.db.memberTypes.findMany({key: 'id', equalsAnyOf: memberTypeIds as string[]});
-
-    const memberTypesById: Record<string, MemberTypeEntity> = {};
-
-    for (const memberType of memberTypes) {
-      memberTypesById[memberType.id] = memberType;
-    }
-
-    return memberTypeIds.map(memberTypeId => memberTypesById[memberTypeId] ?? null);
-  });
-
-  return {
-    userById,
-    usersBySubscribedToUserIds,
-    postsByUserId,
-    profilesByUserId,
-    memberTypeById,
-    populateUserCache: (users: UserEntity[]): void => {
-      for (const user of users) {
-        userById.prime(user.id, user);
-      }
-    },
-    populateMemberTypeCache: (memberTypes: MemberTypeEntity[]): void => {
-      for (const memberType of memberTypes) {
-        memberTypeById.prime(memberType.id, memberType);
-      }
-    }
-  }
-}
 
 export default plugin;

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -40,9 +40,16 @@ const schema = buildSchema(`
 
   type Query {
     users: [User!]!,
+    user(id: ID!): User,
+
     profiles: [Profile!]!,
+    profile(id: ID!): Profile,
+    
     posts: [Post!]!,
+    post(id: ID!): Post,
+    
     memberTypes: [MemberType!]!,
+    memberType(id: ID!): MemberType,
   }
 `);
 
@@ -51,15 +58,27 @@ const rootValue = {
   users: async (args: any, fastify: FastifyInstance) => {
     return await fastify.db.users.findMany();
   },
+  user: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.users.findOne({key: 'id', equals: args.id});
+  },
   profiles: async (args: any, fastify: FastifyInstance) => {
     return await fastify.db.profiles.findMany();
+  },
+  profile: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.profiles.findOne({key: 'id', equals: args.id});
   },
   posts: async (args: any, fastify: FastifyInstance) => {
     return await fastify.db.posts.findMany();
   },
+  post: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.posts.findOne({key: 'id', equals: args.id});
+  },
   memberTypes: async (args: any, fastify: FastifyInstance) => {
     return await fastify.db.memberTypes.findMany();
   },
+  memberType: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.memberTypes.findOne({key: 'id', equals: args.id});
+  }
 };
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -79,7 +79,6 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const { query, variables } = request.body;
       const queryAsString = String(query);
 
-      // @ts-ignore
       const validationErrors = validateQuery(schema, queryAsString, fastify);
 
       if (validationErrors.length > 0) {
@@ -87,7 +86,6 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         return;
       }
 
-      // @ts-ignore
       const loaders = createDataLoaders(fastify);
 
       return await graphql({

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -21,9 +21,12 @@ import { updateProfileQuery } from './profile/updateProfileQuery';
 import { updatePostQuery } from './post/updatePostQuery';
 import { updateMemberTypeQuery } from './memberType/updateMemberTypeQuery';
 import { subscribeUserToQuery } from './user/subscribeUserToQuery';
+import { unsubscribeUserFromQuery } from './user/unsubscribeUserFromQuery';
 
 // tODO check REST patch schemas and allow the only same fields in graphql!
 // todo in graphql, do not use http errors
+// todo check all methods use variables instead of hardcoded values
+// check in some playground - whether there are any warnings / errors
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -48,6 +51,7 @@ const mutationSchema = new GraphQLObjectType({
     createUser: createUserQuery,
     updateUser: updateUserQuery,
     subscribeUserTo: subscribeUserToQuery,
+    unsubscribeUserFrom: unsubscribeUserFromQuery,
 
     createProfile: createProfileQuery,
     updateProfile: updateProfileQuery,

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -19,6 +19,9 @@ import {createPostQuery} from "./post/createPostQuery";
 import {updateUserQuery} from "./user/updateUserQuery";
 import {updateProfileQuery} from "./profile/updateProfileQuery";
 import {updatePostQuery} from "./post/updatePostQuery";
+import {updateMemberTypeQuery} from "./memberType/updateMemberTypeQuery";
+
+// tODO check REST patch schemas and allow the only same fields in graphql!
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -48,6 +51,8 @@ const mutationSchema = new GraphQLObjectType({
 
     createPost: createPostQuery,
     updatePost: updatePostQuery,
+
+    updateMemberType: updateMemberTypeQuery,
   }
 });
 

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -15,13 +15,15 @@ import { memberTypeQuery } from './memberType/memberTypeQuery';
 import { memberTypesQuery } from './memberType/memberTypesQuery';
 import { createUserQuery } from './user/createUserQuery';
 import { createProfileQuery } from './profile/createProfileQuery';
-import {createPostQuery} from "./post/createPostQuery";
-import {updateUserQuery} from "./user/updateUserQuery";
-import {updateProfileQuery} from "./profile/updateProfileQuery";
-import {updatePostQuery} from "./post/updatePostQuery";
-import {updateMemberTypeQuery} from "./memberType/updateMemberTypeQuery";
+import { createPostQuery } from './post/createPostQuery';
+import { updateUserQuery } from './user/updateUserQuery';
+import { updateProfileQuery } from './profile/updateProfileQuery';
+import { updatePostQuery } from './post/updatePostQuery';
+import { updateMemberTypeQuery } from './memberType/updateMemberTypeQuery';
+import { subscribeUserToQuery } from './user/subscribeUserToQuery';
 
 // tODO check REST patch schemas and allow the only same fields in graphql!
+// todo in graphql, do not use http errors
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -45,6 +47,7 @@ const mutationSchema = new GraphQLObjectType({
   fields: {
     createUser: createUserQuery,
     updateUser: updateUserQuery,
+    subscribeUserTo: subscribeUserToQuery,
 
     createProfile: createProfileQuery,
     updateProfile: updateProfileQuery,

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -24,14 +24,25 @@ import { updatePostQuery } from './post/updatePostQuery';
 import { updateMemberTypeQuery } from './memberType/updateMemberTypeQuery';
 import { subscribeUserToQuery } from './user/subscribeUserToQuery';
 import { unsubscribeUserFromQuery } from './user/unsubscribeUserFromQuery';
-const depthLimit = require('graphql-depth-limit');
+import * as depthLimit from 'graphql-depth-limit';
+import {FastifyInstance} from "fastify";
+import {GraphQLError} from "graphql/error/GraphQLError";
+import * as DataLoader from "dataloader";
+import {PostEntity} from "../../utils/DB/entities/DBPosts";
+import * as lodash from 'lodash';
+import {UserEntity} from "../../utils/DB/entities/DBUsers";
+import {ProfileEntity} from "../../utils/DB/entities/DBProfiles";
+import {Loaders} from "./Loaders";
+import {MemberTypeEntity} from "../../utils/DB/entities/DBMemberTypes";
 
 const GRAPHQL_QUERY_DEPTH_LIMIT = 6;
 
 // tODO check REST patch schemas and allow the only same fields in graphql!
 // todo in graphql, do not use http errors
 // todo check all methods use variables instead of hardcoded values
-// check in some playground - whether there are any warnings / errors
+// todo check in some playground - whether there are any warnings / errors
+// todo remove commas (,) from all requests
+// todo add postman collection
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -87,34 +98,124 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const { query, variables } = request.body;
       const queryAsString = String(query);
 
-      let documentAST: DocumentNode;
-      try {
-        documentAST = parse(new Source(queryAsString, 'GraphQL request'));
-      } catch (syntaxError: any) {
-        // Return 400: Bad Request if any syntax errors exist.
-        throw fastify.httpErrors.badRequest(syntaxError.message);
-      }
-
-      const validationErrors = validate(schema, documentAST, [
-        depthLimit(GRAPHQL_QUERY_DEPTH_LIMIT)
-      ]);
+      // @ts-ignore
+      const validationErrors = validateQuery(queryAsString, fastify);
 
       if (validationErrors.length > 0) {
-        reply.send({
-          data: null,
-          errors: validationErrors
-        });
+        reply.send({data: null, errors: validationErrors});
         return;
       }
+
+      // @ts-ignore
+      const loaders = createLoaders(fastify);
 
       return await graphql({
         schema,
         source: queryAsString,
         variableValues: variables,
-        contextValue: fastify,
+        contextValue: {
+          fastify,
+          loaders
+        },
       });
     }
   );
 };
+
+function validateQuery(queryAsString: string, fastify: FastifyInstance): ReadonlyArray<GraphQLError> {
+  let documentAST: DocumentNode;
+
+  try {
+    documentAST = parse(new Source(queryAsString, 'GraphQL request'));
+  } catch (syntaxError: any) {
+    // Return 400: Bad Request if any syntax errors exist.
+    throw fastify.httpErrors.badRequest(syntaxError.message);
+  }
+
+  const validationErrors = validate(schema, documentAST, [
+    depthLimit(GRAPHQL_QUERY_DEPTH_LIMIT)
+  ]);
+
+  return validationErrors;
+}
+
+function createLoaders(fastify: FastifyInstance): Loaders {
+  const postsByUserId = new DataLoader<string, PostEntity[]>(async (userIds: readonly string[]): Promise<PostEntity[][]> => {
+    const posts = await fastify.db.posts.findMany({key: 'userId', equalsAnyOf: userIds as string[]});
+
+    const groupedByUserId = lodash.groupBy(posts, 'userId');
+
+    return userIds.map(userId => groupedByUserId[userId] ?? []);
+  });
+
+  const userById = new DataLoader<string, UserEntity>(async (userIds: readonly string[]): Promise<UserEntity[]> => {
+    const users = await fastify.db.users.findMany({key: 'id', equalsAnyOf: userIds as string[]});
+
+    const usersById: Record<string, UserEntity> = {};
+
+    for (const user of users) {
+      usersById[user.id] = user;
+    }
+
+    return userIds.map(userId => usersById[userId] ?? null);
+  });
+
+  const usersBySubscribedToUserIds = new DataLoader<string, UserEntity[]>(async (userIds: readonly string[]): Promise<UserEntity[][]> => {
+    const users = await fastify.db.users.findMany({key: 'subscribedToUserIds', inArrayAnyOf: userIds as string[]});
+
+    const usersBySubscribedToUserIds: Record<string, UserEntity[]> = {};
+
+    for (const userId of userIds) {
+      for (const user of users) {
+        if (user.subscribedToUserIds.includes(userId)) {
+          if (!usersBySubscribedToUserIds.hasOwnProperty(userId)) {
+            usersBySubscribedToUserIds[userId] = [];
+          }
+          usersBySubscribedToUserIds[userId] = [user, ...usersBySubscribedToUserIds[userId]];
+        }
+      }
+    }
+
+    return userIds.map(userId => usersBySubscribedToUserIds[userId] ?? []);
+  });
+
+  const profilesByUserId = new DataLoader<string, ProfileEntity[]>(async (userIds: readonly string[]): Promise<ProfileEntity[][]> => {
+    const profiles = await fastify.db.profiles.findMany({key: 'userId', equalsAnyOf: userIds as string[]});
+
+    const groupedByUserId = lodash.groupBy(profiles, 'userId');
+
+    return userIds.map(userId => groupedByUserId[userId] ?? []);
+  });
+
+  const memberTypeById = new DataLoader<string, MemberTypeEntity>(async (memberTypeIds: readonly string[]): Promise<MemberTypeEntity[]> => {
+    const memberTypes: MemberTypeEntity[] = await fastify.db.memberTypes.findMany({key: 'id', equalsAnyOf: memberTypeIds as string[]});
+
+    const memberTypesById: Record<string, MemberTypeEntity> = {};
+
+    for (const memberType of memberTypes) {
+      memberTypesById[memberType.id] = memberType;
+    }
+
+    return memberTypeIds.map(memberTypeId => memberTypesById[memberTypeId] ?? null);
+  });
+
+  return {
+    userById,
+    usersBySubscribedToUserIds,
+    postsByUserId,
+    profilesByUserId,
+    memberTypeById,
+    populateUserCache: (users: UserEntity[]): void => {
+      for (const user of users) {
+        userById.prime(user.id, user);
+      }
+    },
+    populateMemberTypeCache: (memberTypes: MemberTypeEntity[]): void => {
+      for (const memberType of memberTypes) {
+        memberTypeById.prime(memberType.id, memberType);
+      }
+    }
+  }
+}
 
 export default plugin;

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -17,6 +17,7 @@ import { createUserQuery } from './user/createUserQuery';
 import { createProfileQuery } from './profile/createProfileQuery';
 import {createPostQuery} from "./post/createPostQuery";
 import {updateUserQuery} from "./user/updateUserQuery";
+import {updateProfileQuery} from "./profile/updateProfileQuery";
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -35,7 +36,6 @@ const querySchema = new GraphQLObjectType({
   }
 });
 
-// todo add new GraphQLNonNull()
 const mutationSchema = new GraphQLObjectType({
   name: 'Mutation',
   fields: {
@@ -43,6 +43,8 @@ const mutationSchema = new GraphQLObjectType({
     updateUser: updateUserQuery,
 
     createProfile: createProfileQuery,
+    updateProfile: updateProfileQuery,
+
     createPost: createPostQuery,
   }
 });
@@ -64,8 +66,6 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply) {
       const { query, variables } = request.body;
-
-      // const result = await this.graphql(query, variables);
 
       return await graphql({
         schema,

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,20 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { graphqlBodySchema } from './schema';
+import { graphql, buildSchema } from 'graphql';
+
+// Construct a schema, using GraphQL schema language
+const schema = buildSchema(`
+  type Query {
+    hello(name: String!): String
+  }
+`);
+
+// The rootValue provides a resolver function for each API endpoint
+const rootValue = {
+  hello: (args: any) => {
+    return `Hello world, ${args.name}!`;
+  },
+};
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -12,9 +27,17 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply) {
-        // const { query, variables } = request.body;
-        //
-        // const result = await this.graphql(query, variables);
+      const { query, variables } = request.body;
+
+      // const result = await this.graphql(query, variables);
+
+      return await graphql({
+        schema,
+        source: String(query),
+        rootValue,
+        variableValues: variables,
+        contextValue: fastify
+      });
     }
   );
 };

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,18 +1,64 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { graphqlBodySchema } from './schema';
 import { graphql, buildSchema } from 'graphql';
+import { FastifyInstance } from 'fastify';
 
 // Construct a schema, using GraphQL schema language
 const schema = buildSchema(`
+  type User {
+    id: ID!
+    firstName: String
+    lastName: String
+    email: String
+    subscribedToUserIds: [Int!]!
+  }
+  
+  type Profile {
+    id: ID!
+    avatar: String!
+    sex: String!
+    birthday: Int!
+    country: String!
+    street: String!
+    city: String!
+    memberTypeId: String!
+    userId: String!
+  }
+  
+  type Post {
+    id: ID!
+    title: String!
+    content: String!
+    userId: String!
+  } 
+  
+  type MemberType {
+    id: ID!
+    discount: Int!,
+    monthPostsLimit: Int!,
+  }
+
   type Query {
-    hello(name: String!): String
+    users: [User!]!,
+    profiles: [Profile!]!,
+    posts: [Post!]!,
+    memberTypes: [MemberType!]!,
   }
 `);
 
 // The rootValue provides a resolver function for each API endpoint
 const rootValue = {
-  hello: (args: any) => {
-    return `Hello world, ${args.name}!`;
+  users: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.users.findMany();
+  },
+  profiles: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.profiles.findMany();
+  },
+  posts: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.posts.findMany();
+  },
+  memberTypes: async (args: any, fastify: FastifyInstance) => {
+    return await fastify.db.memberTypes.findMany();
   },
 };
 
@@ -36,7 +82,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         source: String(query),
         rootValue,
         variableValues: variables,
-        contextValue: fastify
+        contextValue: fastify,
       });
     }
   );

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -18,6 +18,7 @@ import { createProfileQuery } from './profile/createProfileQuery';
 import {createPostQuery} from "./post/createPostQuery";
 import {updateUserQuery} from "./user/updateUserQuery";
 import {updateProfileQuery} from "./profile/updateProfileQuery";
+import {updatePostQuery} from "./post/updatePostQuery";
 
 const querySchema = new GraphQLObjectType({
   name: 'Query',
@@ -46,6 +47,7 @@ const mutationSchema = new GraphQLObjectType({
     updateProfile: updateProfileQuery,
 
     createPost: createPostQuery,
+    updatePost: updatePostQuery,
   }
 });
 

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -25,11 +25,6 @@ import { unsubscribeUserFromQuery } from './user/unsubscribeUserFromQuery';
 import { createDataLoaders } from './createDataLoaders';
 import { validateQuery } from './validateQuery';
 
-// todo bug with setting null
-// todo validate uuid by graphql
-// todo in graphql, do not use http errors
-// todo add postman collection
-
 const querySchema = new GraphQLObjectType({
   name: 'Query',
   fields: {

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,85 +1,39 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { graphqlBodySchema } from './schema';
-import { graphql, buildSchema } from 'graphql';
-import { FastifyInstance } from 'fastify';
+import {
+  graphql,
+  GraphQLSchema,
+  GraphQLObjectType,
+} from 'graphql';
+import {userQuery} from './user/userQuery';
+import {usersQuery} from "./user/usersQuery";
+import {profileQuery} from "./profile/profileQuery";
+import {profilesQuery} from "./profile/profilesQuery";
+import {postQuery} from "./post/postQuery";
+import {postsQuery} from "./post/postsQuery";
+import {memberTypeQuery} from "./memberType/memberTypeQuery";
+import {memberTypesQuery} from "./memberType/memberTypesQuery";
 
-// Construct a schema, using GraphQL schema language
-const schema = buildSchema(`
-  type User {
-    id: ID!
-    firstName: String
-    lastName: String
-    email: String
-    subscribedToUserIds: [Int!]!
-  }
-  
-  type Profile {
-    id: ID!
-    avatar: String!
-    sex: String!
-    birthday: Int!
-    country: String!
-    street: String!
-    city: String!
-    memberTypeId: String!
-    userId: String!
-  }
-  
-  type Post {
-    id: ID!
-    title: String!
-    content: String!
-    userId: String!
-  } 
-  
-  type MemberType {
-    id: ID!
-    discount: Int!,
-    monthPostsLimit: Int!,
-  }
+const querySchema = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    user: userQuery,
+    users: usersQuery,
 
-  type Query {
-    users: [User!]!,
-    user(id: ID!): User,
+    profile: profileQuery,
+    profiles: profilesQuery,
 
-    profiles: [Profile!]!,
-    profile(id: ID!): Profile,
-    
-    posts: [Post!]!,
-    post(id: ID!): Post,
-    
-    memberTypes: [MemberType!]!,
-    memberType(id: ID!): MemberType,
-  }
-`);
+    post: postQuery,
+    posts: postsQuery,
 
-// The rootValue provides a resolver function for each API endpoint
-const rootValue = {
-  users: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.users.findMany();
-  },
-  user: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.users.findOne({key: 'id', equals: args.id});
-  },
-  profiles: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.profiles.findMany();
-  },
-  profile: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.profiles.findOne({key: 'id', equals: args.id});
-  },
-  posts: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.posts.findMany();
-  },
-  post: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.posts.findOne({key: 'id', equals: args.id});
-  },
-  memberTypes: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.memberTypes.findMany();
-  },
-  memberType: async (args: any, fastify: FastifyInstance) => {
-    return await fastify.db.memberTypes.findOne({key: 'id', equals: args.id});
+    memberType: memberTypeQuery,
+    memberTypes: memberTypesQuery,
   }
-};
+});
+
+const schema = new GraphQLSchema({
+  query: querySchema
+});
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -99,7 +53,6 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       return await graphql({
         schema,
         source: String(query),
-        rootValue,
         variableValues: variables,
         contextValue: fastify,
       });

--- a/src/routes/graphql/memberType/memberTypeQuery.ts
+++ b/src/routes/graphql/memberType/memberTypeQuery.ts
@@ -1,6 +1,6 @@
-import {GraphQLString} from "graphql";
-import {memberTypeType} from "./memberTypeType";
-import {ContextValueType} from "../ContextValueType";
+import { GraphQLString } from 'graphql';
+import { memberTypeType } from './memberTypeType';
+import { ContextValueType } from '../ContextValueType';
 
 const memberTypeQuery = {
   type: memberTypeType,

--- a/src/routes/graphql/memberType/memberTypeQuery.ts
+++ b/src/routes/graphql/memberType/memberTypeQuery.ts
@@ -1,0 +1,15 @@
+import {GraphQLString} from "graphql";
+import {FastifyInstance} from "fastify";
+import {memberTypeType} from "./memberTypeType";
+
+const memberTypeQuery = {
+  type: memberTypeType,
+  args: {
+    id: { type: GraphQLString }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.memberTypes.findOne({key: 'id', equals: args.id});
+  }
+};
+
+export { memberTypeQuery };

--- a/src/routes/graphql/memberType/memberTypeQuery.ts
+++ b/src/routes/graphql/memberType/memberTypeQuery.ts
@@ -1,14 +1,14 @@
 import {GraphQLString} from "graphql";
-import {FastifyInstance} from "fastify";
 import {memberTypeType} from "./memberTypeType";
+import {ContextValueType} from "../ContextValueType";
 
 const memberTypeQuery = {
   type: memberTypeType,
   args: {
     id: { type: GraphQLString }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.memberTypes.findOne({key: 'id', equals: args.id});
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    return await context.loaders.memberTypeById.load(args.id);
   }
 };
 

--- a/src/routes/graphql/memberType/memberTypeQuery.ts
+++ b/src/routes/graphql/memberType/memberTypeQuery.ts
@@ -1,13 +1,14 @@
 import { GraphQLString } from 'graphql';
 import { memberTypeType } from './memberTypeType';
 import { ContextValueType } from '../ContextValueType';
+import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
 
 const memberTypeQuery = {
   type: memberTypeType,
   args: {
     id: { type: GraphQLString }
   },
-  resolve: async (_: any, args: any, context: ContextValueType) => {
+  resolve: async (_: any, args: any, context: ContextValueType): Promise<MemberTypeEntity> => {
     return await context.loaders.memberTypeById.load(args.id);
   }
 };

--- a/src/routes/graphql/memberType/memberTypeType.ts
+++ b/src/routes/graphql/memberType/memberTypeType.ts
@@ -1,0 +1,12 @@
+import {GraphQLID, GraphQLInt, GraphQLObjectType} from 'graphql';
+
+const memberTypeType = new GraphQLObjectType({
+  name: 'MemberType',
+  fields: {
+    id: { type: GraphQLID },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  }
+});
+
+export { memberTypeType };

--- a/src/routes/graphql/memberType/memberTypeType.ts
+++ b/src/routes/graphql/memberType/memberTypeType.ts
@@ -1,4 +1,4 @@
-import {GraphQLID, GraphQLInt, GraphQLObjectType} from 'graphql';
+import { GraphQLID, GraphQLInt, GraphQLObjectType } from 'graphql';
 
 const memberTypeType = new GraphQLObjectType({
   name: 'MemberType',

--- a/src/routes/graphql/memberType/memberTypeUpdateInput.ts
+++ b/src/routes/graphql/memberType/memberTypeUpdateInput.ts
@@ -1,0 +1,11 @@
+import { GraphQLInputObjectType, GraphQLInt } from 'graphql';
+
+const memberTypeUpdateInput = new GraphQLInputObjectType({
+  name: 'MemberTypeUpdateInput',
+  fields: () => ({
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  })
+});
+
+export { memberTypeUpdateInput };

--- a/src/routes/graphql/memberType/memberTypesQuery.ts
+++ b/src/routes/graphql/memberType/memberTypesQuery.ts
@@ -1,11 +1,16 @@
 import {GraphQLList} from "graphql";
-import {FastifyInstance} from "fastify";
 import {memberTypeType} from "./memberTypeType";
+import {ContextValueType} from "../ContextValueType";
+import {MemberTypeEntity} from "../../../utils/DB/entities/DBMemberTypes";
 
 const memberTypesQuery = {
   type: new GraphQLList(memberTypeType),
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.memberTypes.findMany();
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const memberTypes: MemberTypeEntity[] = await context.fastify.db.memberTypes.findMany();
+
+    context.loaders.populateMemberTypeCache(memberTypes);
+
+    return memberTypes;
   }
 };
 

--- a/src/routes/graphql/memberType/memberTypesQuery.ts
+++ b/src/routes/graphql/memberType/memberTypesQuery.ts
@@ -1,7 +1,7 @@
-import {GraphQLList} from "graphql";
-import {memberTypeType} from "./memberTypeType";
-import {ContextValueType} from "../ContextValueType";
-import {MemberTypeEntity} from "../../../utils/DB/entities/DBMemberTypes";
+import { GraphQLList } from 'graphql';
+import { memberTypeType } from './memberTypeType';
+import { ContextValueType } from '../ContextValueType';
+import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
 
 const memberTypesQuery = {
   type: new GraphQLList(memberTypeType),

--- a/src/routes/graphql/memberType/memberTypesQuery.ts
+++ b/src/routes/graphql/memberType/memberTypesQuery.ts
@@ -5,7 +5,7 @@ import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
 
 const memberTypesQuery = {
   type: new GraphQLList(memberTypeType),
-  resolve: async (_: any, args: any, context: ContextValueType) => {
+  resolve: async (_: any, args: any, context: ContextValueType): Promise<MemberTypeEntity[]> => {
     const memberTypes: MemberTypeEntity[] = await context.fastify.db.memberTypes.findMany();
 
     context.loaders.populateMemberTypeCache(memberTypes);

--- a/src/routes/graphql/memberType/memberTypesQuery.ts
+++ b/src/routes/graphql/memberType/memberTypesQuery.ts
@@ -1,0 +1,12 @@
+import {GraphQLList} from "graphql";
+import {FastifyInstance} from "fastify";
+import {memberTypeType} from "./memberTypeType";
+
+const memberTypesQuery = {
+  type: new GraphQLList(memberTypeType),
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.memberTypes.findMany();
+  }
+};
+
+export { memberTypesQuery };

--- a/src/routes/graphql/memberType/updateMemberTypeQuery.ts
+++ b/src/routes/graphql/memberType/updateMemberTypeQuery.ts
@@ -1,0 +1,26 @@
+import {FastifyInstance} from "fastify";
+import {GraphQLString} from "graphql";
+import {memberTypeUpdateInput} from "./memberTypeUpdateInput";
+import {memberTypeType} from "./memberTypeType";
+
+const updateMemberTypeQuery = {
+  type: memberTypeType,
+  args: {
+    memberTypeId: { type: GraphQLString },
+    memberType: { type: memberTypeUpdateInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const id = args.memberTypeId;
+    const memberType = await fastify.db.memberTypes.findOne({key: 'id', equals: id});
+
+    if (memberType === null) {
+      throw fastify.httpErrors.badRequest('Member type not found');
+    }
+
+    const updatedMemberType = await fastify.db.memberTypes.change(id, args.memberType);
+
+    return updatedMemberType!;
+  }
+};
+
+export { updateMemberTypeQuery };

--- a/src/routes/graphql/memberType/updateMemberTypeQuery.ts
+++ b/src/routes/graphql/memberType/updateMemberTypeQuery.ts
@@ -3,6 +3,7 @@ import { memberTypeUpdateInput } from './memberTypeUpdateInput';
 import { memberTypeType } from './memberTypeType';
 import { ContextValueType } from '../ContextValueType';
 import { FastifyInstance } from 'fastify';
+import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
 
 const updateMemberTypeQuery = {
   type: memberTypeType,
@@ -10,7 +11,7 @@ const updateMemberTypeQuery = {
     memberTypeId: { type: GraphQLString },
     memberType: { type: memberTypeUpdateInput }
   },
-  resolve: async (_: any, args: any, context: ContextValueType) => {
+  resolve: async (_: any, args: any, context: ContextValueType): Promise<MemberTypeEntity> => {
     const id = args.memberTypeId;
     const fastify: FastifyInstance = context.fastify;
 

--- a/src/routes/graphql/memberType/updateMemberTypeQuery.ts
+++ b/src/routes/graphql/memberType/updateMemberTypeQuery.ts
@@ -1,7 +1,8 @@
-import {FastifyInstance} from "fastify";
 import {GraphQLString} from "graphql";
 import {memberTypeUpdateInput} from "./memberTypeUpdateInput";
 import {memberTypeType} from "./memberTypeType";
+import {ContextValueType} from "../ContextValueType";
+import {FastifyInstance} from "fastify";
 
 const updateMemberTypeQuery = {
   type: memberTypeType,
@@ -9,9 +10,11 @@ const updateMemberTypeQuery = {
     memberTypeId: { type: GraphQLString },
     memberType: { type: memberTypeUpdateInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+  resolve: async (_: any, args: any, context: ContextValueType) => {
     const id = args.memberTypeId;
-    const memberType = await fastify.db.memberTypes.findOne({key: 'id', equals: id});
+    const fastify: FastifyInstance = context.fastify;
+
+    const memberType = await context.loaders.memberTypeById.load(id);
 
     if (memberType === null) {
       throw fastify.httpErrors.badRequest('Member type not found');

--- a/src/routes/graphql/memberType/updateMemberTypeQuery.ts
+++ b/src/routes/graphql/memberType/updateMemberTypeQuery.ts
@@ -1,8 +1,8 @@
-import {GraphQLString} from "graphql";
-import {memberTypeUpdateInput} from "./memberTypeUpdateInput";
-import {memberTypeType} from "./memberTypeType";
-import {ContextValueType} from "../ContextValueType";
-import {FastifyInstance} from "fastify";
+import { GraphQLString } from 'graphql';
+import { memberTypeUpdateInput } from './memberTypeUpdateInput';
+import { memberTypeType } from './memberTypeType';
+import { ContextValueType } from '../ContextValueType';
+import { FastifyInstance } from 'fastify';
 
 const updateMemberTypeQuery = {
   type: memberTypeType,

--- a/src/routes/graphql/post/createPostQuery.ts
+++ b/src/routes/graphql/post/createPostQuery.ts
@@ -2,13 +2,15 @@ import {postCreateInput} from './postCreateInput';
 import {FastifyInstance} from "fastify";
 import {postType} from "./postType";
 import {isUuid} from "../../../utils/isUuid";
+import {ContextValueType} from "../ContextValueType";
 
 const createPostQuery = {
   type: postType,
   args: {
     post: { type: postCreateInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const fastify: FastifyInstance = context.fastify;
     const { userId } = args.post;
 
     if (!isUuid(userId)) {

--- a/src/routes/graphql/post/createPostQuery.ts
+++ b/src/routes/graphql/post/createPostQuery.ts
@@ -1,8 +1,8 @@
-import {postCreateInput} from './postCreateInput';
-import {FastifyInstance} from "fastify";
-import {postType} from "./postType";
-import {isUuid} from "../../../utils/isUuid";
-import {ContextValueType} from "../ContextValueType";
+import { postCreateInput } from './postCreateInput';
+import { FastifyInstance } from 'fastify';
+import { postType } from './postType';
+import { isUuid } from '../../../utils/isUuid';
+import { ContextValueType } from '../ContextValueType';
 
 const createPostQuery = {
   type: postType,

--- a/src/routes/graphql/post/createPostQuery.ts
+++ b/src/routes/graphql/post/createPostQuery.ts
@@ -1,0 +1,30 @@
+import {postInput} from './postInput';
+import {FastifyInstance} from "fastify";
+import {postType} from "./postType";
+import {isUuid} from "../../../utils/isUuid";
+
+const createPostQuery = {
+  type: postType,
+  args: {
+    post: { type: postInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const { userId } = args.post;
+
+    if (!isUuid(userId)) {
+      throw fastify.httpErrors.badRequest('User id is not a valid uuid');
+    }
+
+    const user = await fastify.db.users.findOne({key: 'id', equals: userId});
+
+    if (user === null) {
+      throw fastify.httpErrors.badRequest('User not found');
+    }
+
+    const post = await fastify.db.posts.create(args.post);
+
+    return post;
+  }
+};
+
+export { createPostQuery };

--- a/src/routes/graphql/post/createPostQuery.ts
+++ b/src/routes/graphql/post/createPostQuery.ts
@@ -3,13 +3,14 @@ import { FastifyInstance } from 'fastify';
 import { postType } from './postType';
 import { isUuid } from '../../../utils/isUuid';
 import { ContextValueType } from '../ContextValueType';
+import { PostEntity } from '../../../utils/DB/entities/DBPosts';
 
 const createPostQuery = {
   type: postType,
   args: {
     post: { type: postCreateInput }
   },
-  resolve: async (_: any, args: any, context: ContextValueType) => {
+  resolve: async (_: any, args: any, context: ContextValueType): Promise<PostEntity> => {
     const fastify: FastifyInstance = context.fastify;
     const { userId } = args.post;
 

--- a/src/routes/graphql/post/createPostQuery.ts
+++ b/src/routes/graphql/post/createPostQuery.ts
@@ -1,4 +1,4 @@
-import {postInput} from './postInput';
+import {postCreateInput} from './postCreateInput';
 import {FastifyInstance} from "fastify";
 import {postType} from "./postType";
 import {isUuid} from "../../../utils/isUuid";
@@ -6,7 +6,7 @@ import {isUuid} from "../../../utils/isUuid";
 const createPostQuery = {
   type: postType,
   args: {
-    post: { type: postInput }
+    post: { type: postCreateInput }
   },
   resolve: async (_: any, args: any, fastify: FastifyInstance) => {
     const { userId } = args.post;

--- a/src/routes/graphql/post/postCreateInput.ts
+++ b/src/routes/graphql/post/postCreateInput.ts
@@ -1,0 +1,12 @@
+import {GraphQLString, GraphQLInputObjectType, GraphQLNonNull} from 'graphql';
+
+const postCreateInput = new GraphQLInputObjectType({
+  name: 'PostCreateInput',
+  fields: () => ({
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type:  new GraphQLNonNull(GraphQLString) },
+    userId: { type:  new GraphQLNonNull(GraphQLString) },
+  })
+});
+
+export { postCreateInput };

--- a/src/routes/graphql/post/postCreateInput.ts
+++ b/src/routes/graphql/post/postCreateInput.ts
@@ -1,4 +1,4 @@
-import {GraphQLString, GraphQLInputObjectType, GraphQLNonNull} from 'graphql';
+import { GraphQLString, GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
 
 const postCreateInput = new GraphQLInputObjectType({
   name: 'PostCreateInput',

--- a/src/routes/graphql/post/postInput.ts
+++ b/src/routes/graphql/post/postInput.ts
@@ -1,0 +1,12 @@
+import {GraphQLString, GraphQLInputObjectType} from 'graphql';
+
+const postInput = new GraphQLInputObjectType({
+  name: 'PostInput',
+  fields: () => ({
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  })
+});
+
+export { postInput };

--- a/src/routes/graphql/post/postQuery.ts
+++ b/src/routes/graphql/post/postQuery.ts
@@ -1,0 +1,15 @@
+import {GraphQLString} from "graphql";
+import {FastifyInstance} from "fastify";
+import {postType} from "./postType";
+
+const postQuery = {
+  type: postType,
+  args: {
+    id: { type: GraphQLString }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.posts.findOne({key: 'id', equals: args.id});
+  }
+};
+
+export { postQuery };

--- a/src/routes/graphql/post/postQuery.ts
+++ b/src/routes/graphql/post/postQuery.ts
@@ -1,14 +1,14 @@
 import {GraphQLString} from "graphql";
-import {FastifyInstance} from "fastify";
 import {postType} from "./postType";
+import {ContextValueType} from "../ContextValueType";
 
 const postQuery = {
   type: postType,
   args: {
     id: { type: GraphQLString }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.posts.findOne({key: 'id', equals: args.id});
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    return await context.fastify.db.posts.findOne({key: 'id', equals: args.id});
   }
 };
 

--- a/src/routes/graphql/post/postQuery.ts
+++ b/src/routes/graphql/post/postQuery.ts
@@ -1,6 +1,6 @@
-import {GraphQLString} from "graphql";
-import {postType} from "./postType";
-import {ContextValueType} from "../ContextValueType";
+import { GraphQLString } from 'graphql';
+import { postType } from './postType';
+import { ContextValueType } from '../ContextValueType';
 
 const postQuery = {
   type: postType,

--- a/src/routes/graphql/post/postQuery.ts
+++ b/src/routes/graphql/post/postQuery.ts
@@ -8,7 +8,7 @@ const postQuery = {
     id: { type: GraphQLString }
   },
   resolve: async (_: any, args: any, context: ContextValueType) => {
-    return await context.fastify.db.posts.findOne({key: 'id', equals: args.id});
+    return await context.loaders.postById.load(args.id);
   }
 };
 

--- a/src/routes/graphql/post/postType.ts
+++ b/src/routes/graphql/post/postType.ts
@@ -1,4 +1,4 @@
-import {GraphQLID, GraphQLObjectType, GraphQLString} from 'graphql';
+import { GraphQLID, GraphQLObjectType, GraphQLString } from 'graphql';
 
 const postType = new GraphQLObjectType({
   name: 'Post',

--- a/src/routes/graphql/post/postType.ts
+++ b/src/routes/graphql/post/postType.ts
@@ -1,0 +1,13 @@
+import {GraphQLID, GraphQLObjectType, GraphQLString} from 'graphql';
+
+const postType = new GraphQLObjectType({
+  name: 'Post',
+  fields: {
+    id: { type: GraphQLID },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  }
+});
+
+export { postType };

--- a/src/routes/graphql/post/postUpdateInput.ts
+++ b/src/routes/graphql/post/postUpdateInput.ts
@@ -5,7 +5,6 @@ const postUpdateInput = new GraphQLInputObjectType({
   fields: () => ({
     title: { type: GraphQLString },
     content: { type: GraphQLString },
-    userId: { type: GraphQLString },
   })
 });
 

--- a/src/routes/graphql/post/postUpdateInput.ts
+++ b/src/routes/graphql/post/postUpdateInput.ts
@@ -1,4 +1,4 @@
-import {GraphQLString, GraphQLInputObjectType} from 'graphql';
+import { GraphQLString, GraphQLInputObjectType } from 'graphql';
 
 const postUpdateInput = new GraphQLInputObjectType({
   name: 'PostUpdateInput',

--- a/src/routes/graphql/post/postUpdateInput.ts
+++ b/src/routes/graphql/post/postUpdateInput.ts
@@ -1,7 +1,7 @@
 import {GraphQLString, GraphQLInputObjectType} from 'graphql';
 
-const postInput = new GraphQLInputObjectType({
-  name: 'PostInput',
+const postUpdateInput = new GraphQLInputObjectType({
+  name: 'PostUpdateInput',
   fields: () => ({
     title: { type: GraphQLString },
     content: { type: GraphQLString },
@@ -9,4 +9,4 @@ const postInput = new GraphQLInputObjectType({
   })
 });
 
-export { postInput };
+export { postUpdateInput };

--- a/src/routes/graphql/post/postsQuery.ts
+++ b/src/routes/graphql/post/postsQuery.ts
@@ -1,6 +1,6 @@
-import {GraphQLList} from "graphql";
-import {postType} from "./postType";
-import {ContextValueType} from "../ContextValueType";
+import { GraphQLList } from 'graphql';
+import { postType } from './postType';
+import { ContextValueType } from '../ContextValueType';
 
 const postsQuery = {
   type: new GraphQLList(postType),

--- a/src/routes/graphql/post/postsQuery.ts
+++ b/src/routes/graphql/post/postsQuery.ts
@@ -1,0 +1,12 @@
+import {GraphQLList} from "graphql";
+import {FastifyInstance} from "fastify";
+import {postType} from "./postType";
+
+const postsQuery = {
+  type: new GraphQLList(postType),
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.posts.findMany();
+  }
+};
+
+export { postsQuery}

--- a/src/routes/graphql/post/postsQuery.ts
+++ b/src/routes/graphql/post/postsQuery.ts
@@ -1,11 +1,11 @@
 import {GraphQLList} from "graphql";
-import {FastifyInstance} from "fastify";
 import {postType} from "./postType";
+import {ContextValueType} from "../ContextValueType";
 
 const postsQuery = {
   type: new GraphQLList(postType),
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.posts.findMany();
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    return await context.fastify.db.posts.findMany();
   }
 };
 

--- a/src/routes/graphql/post/updatePostQuery.ts
+++ b/src/routes/graphql/post/updatePostQuery.ts
@@ -1,0 +1,32 @@
+import {FastifyInstance} from "fastify";
+import {postType} from "./postType";
+import {isUuid} from "../../../utils/isUuid";
+import {postUpdateInput} from "./postUpdateInput";
+import {GraphQLString} from "graphql";
+
+const updatePostQuery = {
+  type: postType,
+  args: {
+    postId: { type: GraphQLString },
+    post: { type: postUpdateInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const id = args.postId;
+
+    if (!isUuid(id)) {
+      throw fastify.httpErrors.badRequest('Post id is not a valid uuid');
+    }
+
+    const post = await fastify.db.posts.findOne({key: 'id', equals: id});
+
+    if (post === null) {
+      throw fastify.httpErrors.notFound('Post not found');
+    }
+
+    const changed = await fastify.db.posts.change(id, args.post);
+
+    return changed!;
+  }
+};
+
+export { updatePostQuery };

--- a/src/routes/graphql/post/updatePostQuery.ts
+++ b/src/routes/graphql/post/updatePostQuery.ts
@@ -3,6 +3,7 @@ import {postType} from "./postType";
 import {isUuid} from "../../../utils/isUuid";
 import {postUpdateInput} from "./postUpdateInput";
 import {GraphQLString} from "graphql";
+import {ContextValueType} from "../ContextValueType";
 
 const updatePostQuery = {
   type: postType,
@@ -10,8 +11,9 @@ const updatePostQuery = {
     postId: { type: GraphQLString },
     post: { type: postUpdateInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+  resolve: async (_: any, args: any, context: ContextValueType) => {
     const id = args.postId;
+    const fastify: FastifyInstance = context.fastify;
 
     if (!isUuid(id)) {
       throw fastify.httpErrors.badRequest('Post id is not a valid uuid');

--- a/src/routes/graphql/post/updatePostQuery.ts
+++ b/src/routes/graphql/post/updatePostQuery.ts
@@ -1,9 +1,9 @@
-import {FastifyInstance} from "fastify";
-import {postType} from "./postType";
-import {isUuid} from "../../../utils/isUuid";
-import {postUpdateInput} from "./postUpdateInput";
-import {GraphQLString} from "graphql";
-import {ContextValueType} from "../ContextValueType";
+import { FastifyInstance } from 'fastify';
+import { postType } from './postType';
+import { isUuid } from '../../../utils/isUuid';
+import { postUpdateInput } from './postUpdateInput';
+import { GraphQLString } from 'graphql';
+import { ContextValueType } from '../ContextValueType';
 
 const updatePostQuery = {
   type: postType,

--- a/src/routes/graphql/profile/createProfileQuery.ts
+++ b/src/routes/graphql/profile/createProfileQuery.ts
@@ -1,14 +1,15 @@
 import {FastifyInstance} from "fastify";
 import {profileType} from "./profileType";
 import {profileCreateInput} from "./profileCreateInput";
+import {ContextValueType} from "../ContextValueType";
 
 const createProfileQuery = {
   type: profileType,
   args: {
     profile: { type: profileCreateInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    // todo reuse the code with REST
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const fastify: FastifyInstance = context.fastify;
     const { userId, memberTypeId } = args.profile;
 
     const user = await fastify.db.users.findOne({key: 'id', equals: userId});

--- a/src/routes/graphql/profile/createProfileQuery.ts
+++ b/src/routes/graphql/profile/createProfileQuery.ts
@@ -1,11 +1,11 @@
 import {FastifyInstance} from "fastify";
 import {profileType} from "./profileType";
-import {profileInput} from "./profileInput";
+import {profileCreateInput} from "./profileCreateInput";
 
 const createProfileQuery = {
   type: profileType,
   args: {
-    profile: { type: profileInput }
+    profile: { type: profileCreateInput }
   },
   resolve: async (_: any, args: any, fastify: FastifyInstance) => {
     // todo reuse the code with REST

--- a/src/routes/graphql/profile/createProfileQuery.ts
+++ b/src/routes/graphql/profile/createProfileQuery.ts
@@ -1,0 +1,38 @@
+import {FastifyInstance} from "fastify";
+import {profileType} from "./profileType";
+import {profileInput} from "./profileInput";
+
+const createProfileQuery = {
+  type: profileType,
+  args: {
+    profile: { type: profileInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    // todo reuse the code with REST
+    const { userId, memberTypeId } = args.profile;
+
+    const user = await fastify.db.users.findOne({key: 'id', equals: userId});
+
+    if (user === null) {
+      throw fastify.httpErrors.badRequest('User not found');
+    }
+
+    const profileByUserId = await fastify.db.profiles.findOne({key: 'userId', equals: userId});
+
+    if (profileByUserId !== null) {
+      throw fastify.httpErrors.badRequest('Profile already exists');
+    }
+
+    const memberType = await fastify.db.memberTypes.findOne({key: 'id', equals: memberTypeId});
+
+    if (memberType === null) {
+      throw fastify.httpErrors.badRequest('Member type not found');
+    }
+
+    const profile = await fastify.db.profiles.create(args.profile);
+
+    return profile;
+  }
+};
+
+export { createProfileQuery };

--- a/src/routes/graphql/profile/createProfileQuery.ts
+++ b/src/routes/graphql/profile/createProfileQuery.ts
@@ -1,7 +1,7 @@
-import {FastifyInstance} from "fastify";
-import {profileType} from "./profileType";
-import {profileCreateInput} from "./profileCreateInput";
-import {ContextValueType} from "../ContextValueType";
+import { FastifyInstance } from 'fastify';
+import { profileType } from './profileType';
+import { profileCreateInput } from './profileCreateInput';
+import { ContextValueType } from '../ContextValueType';
 
 const createProfileQuery = {
   type: profileType,

--- a/src/routes/graphql/profile/profileCreateInput.ts
+++ b/src/routes/graphql/profile/profileCreateInput.ts
@@ -1,4 +1,4 @@
-import {GraphQLString, GraphQLInputObjectType, GraphQLInt, GraphQLNonNull} from 'graphql';
+import { GraphQLString, GraphQLInputObjectType, GraphQLInt, GraphQLNonNull } from 'graphql';
 
 const profileCreateInput = new GraphQLInputObjectType({
   name: 'ProfileCreateInput',

--- a/src/routes/graphql/profile/profileCreateInput.ts
+++ b/src/routes/graphql/profile/profileCreateInput.ts
@@ -1,0 +1,17 @@
+import {GraphQLString, GraphQLInputObjectType, GraphQLInt, GraphQLNonNull} from 'graphql';
+
+const profileCreateInput = new GraphQLInputObjectType({
+  name: 'ProfileCreateInput',
+  fields: () => ({
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
+  })
+});
+
+export { profileCreateInput };

--- a/src/routes/graphql/profile/profileInput.ts
+++ b/src/routes/graphql/profile/profileInput.ts
@@ -1,0 +1,17 @@
+import {GraphQLString, GraphQLInputObjectType, GraphQLInt} from 'graphql';
+
+const profileInput = new GraphQLInputObjectType({
+  name: 'ProfileInput',
+  fields: () => ({
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    userId: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+  })
+});
+
+export { profileInput };

--- a/src/routes/graphql/profile/profileQuery.ts
+++ b/src/routes/graphql/profile/profileQuery.ts
@@ -1,14 +1,14 @@
 import {GraphQLString} from "graphql";
-import {FastifyInstance} from "fastify";
 import {profileType} from "./profileType";
+import {ContextValueType} from "../ContextValueType";
 
 const profileQuery = {
   type: profileType,
   args: {
     id: { type: GraphQLString }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.profiles.findOne({key: 'id', equals: args.id});
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    return await context.fastify.db.profiles.findOne({key: 'id', equals: args.id});
   }
 };
 

--- a/src/routes/graphql/profile/profileQuery.ts
+++ b/src/routes/graphql/profile/profileQuery.ts
@@ -1,0 +1,15 @@
+import {GraphQLString} from "graphql";
+import {FastifyInstance} from "fastify";
+import {profileType} from "./profileType";
+
+const profileQuery = {
+  type: profileType,
+  args: {
+    id: { type: GraphQLString }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.profiles.findOne({key: 'id', equals: args.id});
+  }
+};
+
+export { profileQuery };

--- a/src/routes/graphql/profile/profileQuery.ts
+++ b/src/routes/graphql/profile/profileQuery.ts
@@ -1,6 +1,6 @@
-import {GraphQLString} from "graphql";
-import {profileType} from "./profileType";
-import {ContextValueType} from "../ContextValueType";
+import { GraphQLString } from 'graphql';
+import { profileType } from './profileType';
+import { ContextValueType } from '../ContextValueType';
 
 const profileQuery = {
   type: profileType,

--- a/src/routes/graphql/profile/profileQuery.ts
+++ b/src/routes/graphql/profile/profileQuery.ts
@@ -8,7 +8,7 @@ const profileQuery = {
     id: { type: GraphQLString }
   },
   resolve: async (_: any, args: any, context: ContextValueType) => {
-    return await context.fastify.db.profiles.findOne({key: 'id', equals: args.id});
+    return await context.loaders.profileById.load(args.id);
   }
 };
 

--- a/src/routes/graphql/profile/profileType.ts
+++ b/src/routes/graphql/profile/profileType.ts
@@ -1,0 +1,18 @@
+import {GraphQLID, GraphQLInt, GraphQLObjectType, GraphQLString} from 'graphql';
+
+const profileType = new GraphQLObjectType({
+  name: 'Profile',
+  fields: {
+    id: { type: GraphQLID },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  }
+});
+
+export { profileType };

--- a/src/routes/graphql/profile/profileType.ts
+++ b/src/routes/graphql/profile/profileType.ts
@@ -1,4 +1,4 @@
-import {GraphQLID, GraphQLInt, GraphQLObjectType, GraphQLString} from 'graphql';
+import { GraphQLID, GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
 
 const profileType = new GraphQLObjectType({
   name: 'Profile',

--- a/src/routes/graphql/profile/profileUpdateInput.ts
+++ b/src/routes/graphql/profile/profileUpdateInput.ts
@@ -9,6 +9,7 @@ const profileUpdateInput = new GraphQLInputObjectType({
     country: { type: GraphQLString },
     street: { type: GraphQLString },
     city: { type: GraphQLString },
+    // todo validate uuid by graphql
     userId: { type: GraphQLString },
     memberTypeId: { type: GraphQLString },
   })

--- a/src/routes/graphql/profile/profileUpdateInput.ts
+++ b/src/routes/graphql/profile/profileUpdateInput.ts
@@ -1,7 +1,7 @@
 import {GraphQLString, GraphQLInputObjectType, GraphQLInt} from 'graphql';
 
-const profileInput = new GraphQLInputObjectType({
-  name: 'ProfileInput',
+const profileUpdateInput = new GraphQLInputObjectType({
+  name: 'ProfileUpdateInput',
   fields: () => ({
     avatar: { type: GraphQLString },
     sex: { type: GraphQLString },
@@ -14,4 +14,4 @@ const profileInput = new GraphQLInputObjectType({
   })
 });
 
-export { profileInput };
+export { profileUpdateInput };

--- a/src/routes/graphql/profile/profileUpdateInput.ts
+++ b/src/routes/graphql/profile/profileUpdateInput.ts
@@ -1,4 +1,4 @@
-import {GraphQLString, GraphQLInputObjectType, GraphQLInt} from 'graphql';
+import { GraphQLString, GraphQLInputObjectType, GraphQLInt } from 'graphql';
 
 const profileUpdateInput = new GraphQLInputObjectType({
   name: 'ProfileUpdateInput',

--- a/src/routes/graphql/profile/profileUpdateInput.ts
+++ b/src/routes/graphql/profile/profileUpdateInput.ts
@@ -9,8 +9,6 @@ const profileUpdateInput = new GraphQLInputObjectType({
     country: { type: GraphQLString },
     street: { type: GraphQLString },
     city: { type: GraphQLString },
-    // todo validate uuid by graphql
-    userId: { type: GraphQLString },
     memberTypeId: { type: GraphQLString },
   })
 });

--- a/src/routes/graphql/profile/profilesQuery.ts
+++ b/src/routes/graphql/profile/profilesQuery.ts
@@ -1,11 +1,11 @@
 import {GraphQLList} from 'graphql';
-import {FastifyInstance} from 'fastify';
 import {profileType} from './profileType';
+import {ContextValueType} from "../ContextValueType";
 
 const profilesQuery = {
   type: new GraphQLList(profileType),
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.profiles.findMany();
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    return await context.fastify.db.profiles.findMany();
   }
 };
 

--- a/src/routes/graphql/profile/profilesQuery.ts
+++ b/src/routes/graphql/profile/profilesQuery.ts
@@ -1,0 +1,12 @@
+import {GraphQLList} from 'graphql';
+import {FastifyInstance} from 'fastify';
+import {profileType} from './profileType';
+
+const profilesQuery = {
+  type: new GraphQLList(profileType),
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.profiles.findMany();
+  }
+};
+
+export { profilesQuery };

--- a/src/routes/graphql/profile/profilesQuery.ts
+++ b/src/routes/graphql/profile/profilesQuery.ts
@@ -1,6 +1,6 @@
-import {GraphQLList} from 'graphql';
-import {profileType} from './profileType';
-import {ContextValueType} from "../ContextValueType";
+import { GraphQLList } from 'graphql';
+import { profileType } from './profileType';
+import { ContextValueType } from '../ContextValueType';
 
 const profilesQuery = {
   type: new GraphQLList(profileType),

--- a/src/routes/graphql/profile/updateProfileQuery.ts
+++ b/src/routes/graphql/profile/updateProfileQuery.ts
@@ -1,9 +1,9 @@
-import {FastifyInstance} from "fastify";
-import {profileType} from "./profileType";
-import {GraphQLString} from "graphql";
-import {isUuid} from "../../../utils/isUuid";
-import {profileUpdateInput} from "./profileUpdateInput";
-import {ContextValueType} from "../ContextValueType";
+import { FastifyInstance } from 'fastify';
+import { profileType } from './profileType';
+import { GraphQLString } from 'graphql';
+import { isUuid } from '../../../utils/isUuid';
+import { profileUpdateInput } from './profileUpdateInput';
+import { ContextValueType } from '../ContextValueType';
 
 const updateProfileQuery = {
   type: profileType,

--- a/src/routes/graphql/profile/updateProfileQuery.ts
+++ b/src/routes/graphql/profile/updateProfileQuery.ts
@@ -3,6 +3,7 @@ import {profileType} from "./profileType";
 import {GraphQLString} from "graphql";
 import {isUuid} from "../../../utils/isUuid";
 import {profileUpdateInput} from "./profileUpdateInput";
+import {ContextValueType} from "../ContextValueType";
 
 const updateProfileQuery = {
   type: profileType,
@@ -10,7 +11,8 @@ const updateProfileQuery = {
     profileId: { type: GraphQLString },
     profile: { type: profileUpdateInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const fastify: FastifyInstance = context.fastify;
     const id = args.profileId;
 
     if (!isUuid(id)) {

--- a/src/routes/graphql/profile/updateProfileQuery.ts
+++ b/src/routes/graphql/profile/updateProfileQuery.ts
@@ -1,0 +1,32 @@
+import {FastifyInstance} from "fastify";
+import {profileType} from "./profileType";
+import {GraphQLString} from "graphql";
+import {isUuid} from "../../../utils/isUuid";
+import {profileUpdateInput} from "./profileUpdateInput";
+
+const updateProfileQuery = {
+  type: profileType,
+  args: {
+    profileId: { type: GraphQLString },
+    profile: { type: profileUpdateInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const id = args.profileId;
+
+    if (!isUuid(id)) {
+      throw fastify.httpErrors.badRequest('Profile id is not a valid uuid');
+    }
+
+    const profile = await fastify.db.profiles.findOne({key: 'id', equals: id});
+
+    if (profile === null) {
+      throw fastify.httpErrors.notFound('Profile not found');
+    }
+
+    const updatedProfile = await fastify.db.profiles.change(id, args.profile);
+
+    return updatedProfile!;
+  }
+};
+
+export { updateProfileQuery };

--- a/src/routes/graphql/user/createUserQuery.ts
+++ b/src/routes/graphql/user/createUserQuery.ts
@@ -1,14 +1,14 @@
 import {userCreateInput} from './userCreateInput';
-import {FastifyInstance} from "fastify";
 import {userType} from "./userType";
+import {ContextValueType} from "../ContextValueType";
 
 const createUserQuery = {
   type: userType,
   args: {
     user: { type: userCreateInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    const user = await fastify.db.users.create(args.user);
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const user = await context.fastify.db.users.create(args.user);
 
     return user;
   }

--- a/src/routes/graphql/user/createUserQuery.ts
+++ b/src/routes/graphql/user/createUserQuery.ts
@@ -1,6 +1,6 @@
-import {userCreateInput} from './userCreateInput';
-import {userType} from "./userType";
-import {ContextValueType} from "../ContextValueType";
+import { userCreateInput } from './userCreateInput';
+import { userType } from './userType';
+import { ContextValueType } from '../ContextValueType';
 
 const createUserQuery = {
   type: userType,

--- a/src/routes/graphql/user/createUserQuery.ts
+++ b/src/routes/graphql/user/createUserQuery.ts
@@ -1,0 +1,17 @@
+import {userCreateInput} from './userCreateInput';
+import {FastifyInstance} from "fastify";
+import {userType} from "./userType";
+
+const createUserQuery = {
+  type: userType,
+  args: {
+    user: { type: userCreateInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const user = await fastify.db.users.create(args.user);
+
+    return user;
+  }
+};
+
+export { createUserQuery };

--- a/src/routes/graphql/user/subscribeUserToQuery.ts
+++ b/src/routes/graphql/user/subscribeUserToQuery.ts
@@ -1,0 +1,38 @@
+import {FastifyInstance} from "fastify";
+import {userType} from "./userType";
+import {userSubscribeToInput} from "./userSubscribeToInput";
+
+const subscribeUserToQuery = {
+  type: userType,
+  args: {
+    payload: { type: userSubscribeToInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const currentUserId = args.payload.currentUserId;
+    const subscribeToUserId = args.payload.subscribeToUserId;
+
+    const currentUser = await fastify.db.users.findOne({key: 'id', equals: currentUserId});
+
+    if (currentUser === null) {
+      throw fastify.httpErrors.notFound('Current user not found');
+    }
+
+    const userSubscribeTo = await fastify.db.users.findOne({key: 'id', equals: subscribeToUserId});
+
+    if (userSubscribeTo === null) {
+      throw fastify.httpErrors.notFound('User to subscribe to not found');
+    }
+
+    if (userSubscribeTo.subscribedToUserIds.includes(currentUserId)) {
+      throw fastify.httpErrors.badRequest('User already subscribed to');
+    }
+
+    userSubscribeTo.subscribedToUserIds.push(currentUserId);
+
+    await fastify.db.users.change(subscribeToUserId, userSubscribeTo);
+
+    return currentUser;
+  }
+};
+
+export { subscribeUserToQuery };

--- a/src/routes/graphql/user/subscribeUserToQuery.ts
+++ b/src/routes/graphql/user/subscribeUserToQuery.ts
@@ -1,13 +1,15 @@
 import {FastifyInstance} from "fastify";
 import {userType} from "./userType";
 import {userSubscribeToInput} from "./userSubscribeToInput";
+import {ContextValueType} from "../ContextValueType";
 
 const subscribeUserToQuery = {
   type: userType,
   args: {
     payload: { type: userSubscribeToInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const fastify: FastifyInstance = context.fastify;
     const currentUserId = args.payload.currentUserId;
     const subscribeToUserId = args.payload.subscribeToUserId;
 

--- a/src/routes/graphql/user/subscribeUserToQuery.ts
+++ b/src/routes/graphql/user/subscribeUserToQuery.ts
@@ -1,7 +1,7 @@
-import {FastifyInstance} from "fastify";
-import {userType} from "./userType";
-import {userSubscribeToInput} from "./userSubscribeToInput";
-import {ContextValueType} from "../ContextValueType";
+import { FastifyInstance } from 'fastify';
+import { userType } from './userType';
+import { userSubscribeToInput } from './userSubscribeToInput';
+import { ContextValueType } from '../ContextValueType';
 
 const subscribeUserToQuery = {
   type: userType,

--- a/src/routes/graphql/user/unsubscribeUserFromQuery.ts
+++ b/src/routes/graphql/user/unsubscribeUserFromQuery.ts
@@ -1,0 +1,41 @@
+import {FastifyInstance} from "fastify";
+import {userType} from "./userType";
+import {userUnsubscribeFromInput} from "./userUnsubscribeFromInput";
+import {UserEntity} from "../../../utils/DB/entities/DBUsers";
+import {removeArrayItem} from "../../../utils/removeArrayItem";
+
+const unsubscribeUserFromQuery = {
+  type: userType,
+  args: {
+    payload: { type: userUnsubscribeFromInput }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance): Promise<UserEntity> => {
+    const unsubscribeFromUserId = args.payload.unsubscribeFromUserId;
+    const currentUserId = args.payload.currentUserId;
+
+    const userUnsubscribeFrom = await fastify.db.users.findOne({key: 'id', equals: unsubscribeFromUserId});
+
+    if (userUnsubscribeFrom === null) {
+      throw fastify.httpErrors.notFound('User to unsubscribe from not found');
+    }
+
+    const currentUser = await fastify.db.users.findOne({key: 'id', equals: currentUserId});
+
+    if (currentUser === null) {
+      throw fastify.httpErrors.notFound('Current user not found');
+    }
+
+    // `subscribedToUserIds` - this is who subscribed to `user` - followers
+    if (!userUnsubscribeFrom.subscribedToUserIds.includes(currentUserId)) {
+      throw fastify.httpErrors.badRequest('User not subscribed to');
+    }
+
+    removeArrayItem(userUnsubscribeFrom.subscribedToUserIds, currentUserId);
+
+    await fastify.db.users.change(unsubscribeFromUserId, userUnsubscribeFrom);
+
+    return currentUser;
+  }
+};
+
+export { unsubscribeUserFromQuery };

--- a/src/routes/graphql/user/unsubscribeUserFromQuery.ts
+++ b/src/routes/graphql/user/unsubscribeUserFromQuery.ts
@@ -3,13 +3,15 @@ import {userType} from "./userType";
 import {userUnsubscribeFromInput} from "./userUnsubscribeFromInput";
 import {UserEntity} from "../../../utils/DB/entities/DBUsers";
 import {removeArrayItem} from "../../../utils/removeArrayItem";
+import {ContextValueType} from "../ContextValueType";
 
 const unsubscribeUserFromQuery = {
   type: userType,
   args: {
     payload: { type: userUnsubscribeFromInput }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance): Promise<UserEntity> => {
+  resolve: async (_: any, args: any, context: ContextValueType): Promise<UserEntity> => {
+    const fastify: FastifyInstance = context.fastify;
     const unsubscribeFromUserId = args.payload.unsubscribeFromUserId;
     const currentUserId = args.payload.currentUserId;
 

--- a/src/routes/graphql/user/unsubscribeUserFromQuery.ts
+++ b/src/routes/graphql/user/unsubscribeUserFromQuery.ts
@@ -1,9 +1,9 @@
-import {FastifyInstance} from "fastify";
-import {userType} from "./userType";
-import {userUnsubscribeFromInput} from "./userUnsubscribeFromInput";
-import {UserEntity} from "../../../utils/DB/entities/DBUsers";
-import {removeArrayItem} from "../../../utils/removeArrayItem";
-import {ContextValueType} from "../ContextValueType";
+import { FastifyInstance } from 'fastify';
+import { userType } from './userType';
+import { userUnsubscribeFromInput } from './userUnsubscribeFromInput';
+import { UserEntity } from '../../../utils/DB/entities/DBUsers';
+import { removeArrayItem } from '../../../utils/removeArrayItem';
+import { ContextValueType } from '../ContextValueType';
 
 const unsubscribeUserFromQuery = {
   type: userType,

--- a/src/routes/graphql/user/updateUserQuery.ts
+++ b/src/routes/graphql/user/updateUserQuery.ts
@@ -3,6 +3,7 @@ import {userType} from "./userType";
 import {isUuid} from "../../../utils/isUuid";
 import {GraphQLString} from "graphql";
 import {userUpdateInput} from "./userUpdateInput";
+import {ContextValueType} from "../ContextValueType";
 
 const updateUserQuery = {
   type: userType,
@@ -10,7 +11,8 @@ const updateUserQuery = {
     user: { type: userUpdateInput },
     userId: { type: GraphQLString }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const fastify: FastifyInstance = context.fastify;
     const id = args.userId;
 
     if (!isUuid(id)) {

--- a/src/routes/graphql/user/updateUserQuery.ts
+++ b/src/routes/graphql/user/updateUserQuery.ts
@@ -1,0 +1,32 @@
+import {FastifyInstance} from "fastify";
+import {userType} from "./userType";
+import {isUuid} from "../../../utils/isUuid";
+import {GraphQLString} from "graphql";
+import {userUpdateInput} from "./userUpdateInput";
+
+const updateUserQuery = {
+  type: userType,
+  args: {
+    user: { type: userUpdateInput },
+    userId: { type: GraphQLString }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    const id = args.userId;
+
+    if (!isUuid(id)) {
+      throw fastify.httpErrors.badRequest('User id is not a valid uuid');
+    }
+
+    const user = await fastify.db.users.findOne({key: 'id', equals: id});
+
+    if (user === null) {
+      throw fastify.httpErrors.notFound('User not found');
+    }
+
+    const changedUser = await fastify.db.users.change(id, args.user);
+
+    return changedUser!;
+  }
+};
+
+export { updateUserQuery };

--- a/src/routes/graphql/user/updateUserQuery.ts
+++ b/src/routes/graphql/user/updateUserQuery.ts
@@ -1,9 +1,9 @@
-import {FastifyInstance} from "fastify";
-import {userType} from "./userType";
-import {isUuid} from "../../../utils/isUuid";
-import {GraphQLString} from "graphql";
-import {userUpdateInput} from "./userUpdateInput";
-import {ContextValueType} from "../ContextValueType";
+import { FastifyInstance } from 'fastify';
+import { userType } from './userType';
+import { isUuid } from '../../../utils/isUuid';
+import { GraphQLString } from 'graphql';
+import { userUpdateInput } from './userUpdateInput';
+import { ContextValueType } from '../ContextValueType';
 
 const updateUserQuery = {
   type: userType,

--- a/src/routes/graphql/user/userCreateInput.ts
+++ b/src/routes/graphql/user/userCreateInput.ts
@@ -1,0 +1,12 @@
+import {GraphQLString, GraphQLInputObjectType, GraphQLNonNull} from 'graphql';
+
+const userCreateInput = new GraphQLInputObjectType({
+  name: 'UserCreateInput',
+  fields: () => ({
+    firstName: { type:  new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+  })
+});
+
+export { userCreateInput };

--- a/src/routes/graphql/user/userCreateInput.ts
+++ b/src/routes/graphql/user/userCreateInput.ts
@@ -1,4 +1,4 @@
-import {GraphQLString, GraphQLInputObjectType, GraphQLNonNull} from 'graphql';
+import { GraphQLString, GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
 
 const userCreateInput = new GraphQLInputObjectType({
   name: 'UserCreateInput',

--- a/src/routes/graphql/user/userQuery.ts
+++ b/src/routes/graphql/user/userQuery.ts
@@ -8,9 +8,7 @@ const userQuery = {
     id: { type: GraphQLString }
   },
   resolve: async (_: any, args: any, context: ContextValueType) => {
-    const userById = context.loaders.userById;
-
-    return await userById.load(args.id);
+    return await context.loaders.userById.load(args.id);
   }
 };
 

--- a/src/routes/graphql/user/userQuery.ts
+++ b/src/routes/graphql/user/userQuery.ts
@@ -1,0 +1,15 @@
+import {userType} from "./userType";
+import {GraphQLString} from "graphql";
+import {FastifyInstance} from "fastify";
+
+const userQuery = {
+  type: userType,
+  args: {
+    id: { type: GraphQLString }
+  },
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.users.findOne({key: 'id', equals: args.id});
+  }
+};
+
+export { userQuery };

--- a/src/routes/graphql/user/userQuery.ts
+++ b/src/routes/graphql/user/userQuery.ts
@@ -1,14 +1,16 @@
 import {userType} from "./userType";
 import {GraphQLString} from "graphql";
-import {FastifyInstance} from "fastify";
+import {ContextValueType} from "../ContextValueType";
 
 const userQuery = {
   type: userType,
   args: {
     id: { type: GraphQLString }
   },
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.users.findOne({key: 'id', equals: args.id});
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const userById = context.loaders.userById;
+
+    return await userById.load(args.id);
   }
 };
 

--- a/src/routes/graphql/user/userQuery.ts
+++ b/src/routes/graphql/user/userQuery.ts
@@ -1,6 +1,6 @@
-import {userType} from "./userType";
-import {GraphQLString} from "graphql";
-import {ContextValueType} from "../ContextValueType";
+import { userType } from './userType';
+import { GraphQLString } from 'graphql';
+import { ContextValueType } from '../ContextValueType';
 
 const userQuery = {
   type: userType,

--- a/src/routes/graphql/user/userSubscribeToInput.ts
+++ b/src/routes/graphql/user/userSubscribeToInput.ts
@@ -1,0 +1,11 @@
+import { GraphQLInputObjectType, GraphQLNonNull, GraphQLID } from 'graphql';
+
+const userSubscribeToInput = new GraphQLInputObjectType({
+  name: 'UserSubscribeToInput',
+  fields: () => ({
+    currentUserId: { type: new GraphQLNonNull(GraphQLID) },
+    subscribeToUserId: { type: new GraphQLNonNull(GraphQLID) },
+  })
+});
+
+export { userSubscribeToInput };

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -17,13 +17,13 @@ const userType = new GraphQLObjectType({
         return await fastify.db.posts.findMany({key: 'userId', equals: user.id});
       }
     },
-    profiles: {
+    profile: {
       type: new GraphQLList(profileType),
       resolve: async (user: any, args: any, fastify: any) => {
         return await fastify.db.profiles.findMany({key: 'userId', equals: user.id});
       }
     },
-    memberTypes: {
+    memberType: {
       type: new GraphQLList(memberTypeType),
       resolve: async (user: any, args: any, fastify: any) => {
         const profiles = await fastify.db.profiles.findMany({key: 'userId', equals: user.id});

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -1,0 +1,14 @@
+import {GraphQLID, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString} from 'graphql';
+
+const userType = new GraphQLObjectType({
+  name: 'User',
+  fields: {
+    id: { type: GraphQLID },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLInt) },
+  }
+});
+
+export { userType };

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -27,6 +27,9 @@ const userType = new GraphQLObjectType({
     memberType: {
       type: memberTypeType,
       resolve: async (user: any, args: any, fastify: any) => {
+        // todo complete cross-check for remote-control
+
+
         // todo Плюсую. Оба пункта, в которых нужно возвращать memberType (2.3 и 2.4) идут вместе с профилем. Технически можно и юзеру добавить нужный резолвер, но через профиль выглядит логичнее
         const profile = await fastify.db.profiles.findOne({key: 'userId', equals: user.id});
 
@@ -42,6 +45,13 @@ const userType = new GraphQLObjectType({
       type: new GraphQLList(userType),
       resolve: async (user: any, args: any, fastify: any) => {
         return await fastify.db.users.findMany({key: 'subscribedToUserIds', inArray: user.id});
+      }
+    },
+    // these are users who are following the current user.
+    subscribedToUser: {
+      type: new GraphQLList(userType),
+      resolve: async (user: any, args: any, fastify: any) => {
+        return await fastify.db.users.findMany({key: 'id', equalsAnyOf: user.subscribedToUserIds});
       }
     }
   })

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -2,6 +2,7 @@ import {GraphQLID, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString} fr
 import {postType} from "../post/postType";
 import {profileType} from "../profile/profileType";
 import {memberTypeType} from "../memberType/memberTypeType";
+import {FastifyInstance} from "fastify";
 
 // @ts-ignore
 const userType = new GraphQLObjectType({
@@ -14,19 +15,19 @@ const userType = new GraphQLObjectType({
     subscribedToUserIds: { type: new GraphQLList(GraphQLInt) },
     posts: {
       type: new GraphQLList(postType),
-      resolve: async (user: any, args: any, fastify: any) => {
+      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
         return await fastify.db.posts.findMany({key: 'userId', equals: user.id});
       }
     },
     profile: {
       type: profileType,
-      resolve: async (user: any, args: any, fastify: any) => {
+      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
         return await fastify.db.profiles.findOne({key: 'userId', equals: user.id});
       }
     },
     memberType: {
       type: memberTypeType,
-      resolve: async (user: any, args: any, fastify: any) => {
+      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
         // todo complete cross-check for remote-control
 
 
@@ -43,14 +44,14 @@ const userType = new GraphQLObjectType({
     // these are users that the current user is following.
     userSubscribedTo: {
       type: new GraphQLList(userType),
-      resolve: async (user: any, args: any, fastify: any) => {
+      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
         return await fastify.db.users.findMany({key: 'subscribedToUserIds', inArray: user.id});
       }
     },
     // these are users who are following the current user.
     subscribedToUser: {
       type: new GraphQLList(userType),
-      resolve: async (user: any, args: any, fastify: any) => {
+      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
         return await fastify.db.users.findMany({key: 'id', equalsAnyOf: user.subscribedToUserIds});
       }
     }

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -1,4 +1,7 @@
 import {GraphQLID, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString} from 'graphql';
+import {postType} from "../post/postType";
+import {profileType} from "../profile/profileType";
+import {memberTypeType} from "../memberType/memberTypeType";
 
 const userType = new GraphQLObjectType({
   name: 'User',
@@ -8,6 +11,30 @@ const userType = new GraphQLObjectType({
     lastName: { type: GraphQLString },
     email: { type: GraphQLString },
     subscribedToUserIds: { type: new GraphQLList(GraphQLInt) },
+    posts: {
+      type: new GraphQLList(postType),
+      resolve: async (user: any, args: any, fastify: any) => {
+        return await fastify.db.posts.findMany({key: 'userId', equals: user.id});
+      }
+    },
+    profiles: {
+      type: new GraphQLList(profileType),
+      resolve: async (user: any, args: any, fastify: any) => {
+        return await fastify.db.profiles.findMany({key: 'userId', equals: user.id});
+      }
+    },
+    memberTypes: {
+      type: new GraphQLList(memberTypeType),
+      resolve: async (user: any, args: any, fastify: any) => {
+        const profiles = await fastify.db.profiles.findMany({key: 'userId', equals: user.id});
+
+        if (profiles.length === 0) {
+          return Promise.resolve([]);
+        }
+
+        return await fastify.db.memberTypes.findMany({key: 'id', equals: profiles[0].memberTypeId});
+      }
+    }
   }
 });
 

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -1,8 +1,8 @@
-import {GraphQLID, GraphQLList, GraphQLObjectType, GraphQLString} from 'graphql';
-import {postType} from "../post/postType";
-import {profileType} from "../profile/profileType";
-import {memberTypeType} from "../memberType/memberTypeType";
-import {ContextValueType} from "../ContextValueType";
+import { GraphQLID, GraphQLList, GraphQLObjectType, GraphQLString } from 'graphql';
+import { postType} from '../post/postType';
+import { profileType} from '../profile/profileType';
+import { memberTypeType} from '../memberType/memberTypeType';
+import { ContextValueType} from '../ContextValueType';
 
 // @ts-ignore
 const userType = new GraphQLObjectType({

--- a/src/routes/graphql/user/userType.ts
+++ b/src/routes/graphql/user/userType.ts
@@ -1,8 +1,8 @@
-import {GraphQLID, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString} from 'graphql';
+import {GraphQLID, GraphQLList, GraphQLObjectType, GraphQLString} from 'graphql';
 import {postType} from "../post/postType";
 import {profileType} from "../profile/profileType";
 import {memberTypeType} from "../memberType/memberTypeType";
-import {FastifyInstance} from "fastify";
+import {ContextValueType} from "../ContextValueType";
 
 // @ts-ignore
 const userType = new GraphQLObjectType({
@@ -12,47 +12,55 @@ const userType = new GraphQLObjectType({
     firstName: { type: GraphQLString },
     lastName: { type: GraphQLString },
     email: { type: GraphQLString },
-    subscribedToUserIds: { type: new GraphQLList(GraphQLInt) },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
     posts: {
       type: new GraphQLList(postType),
-      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
-        return await fastify.db.posts.findMany({key: 'userId', equals: user.id});
+      resolve: async (user: any, args: any, context: ContextValueType) => {
+        const postsByUserId = context.loaders.postsByUserId;
+
+        return await postsByUserId.load(user.id);
       }
     },
     profile: {
       type: profileType,
-      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
-        return await fastify.db.profiles.findOne({key: 'userId', equals: user.id});
+      resolve: async (user: any, args: any, context: ContextValueType) => {
+        const profilesByUserId = context.loaders.profilesByUserId;
+
+        const profiles = await profilesByUserId.load(user.id);
+
+        return profiles.length === 0 ? null : profiles[0];
       }
     },
     memberType: {
       type: memberTypeType,
-      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
-        // todo complete cross-check for remote-control
+      resolve: async (user: any, args: any, context: ContextValueType) => {
+        const profilesByUserId = context.loaders.profilesByUserId;
+        const profiles = await profilesByUserId.load(user.id);
 
-
-        // todo Плюсую. Оба пункта, в которых нужно возвращать memberType (2.3 и 2.4) идут вместе с профилем. Технически можно и юзеру добавить нужный резолвер, но через профиль выглядит логичнее
-        const profile = await fastify.db.profiles.findOne({key: 'userId', equals: user.id});
-
-        if (profile === null) {
+        if (profiles.length === 0) {
           return Promise.resolve(null);
         }
 
-        return await fastify.db.memberTypes.findOne({key: 'id', equals: profile.memberTypeId});
+        const memberTypeById = context.loaders.memberTypeById;
+
+        return await memberTypeById.load(profiles[0].memberTypeId);
       }
     },
     // these are users that the current user is following.
     userSubscribedTo: {
       type: new GraphQLList(userType),
-      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
-        return await fastify.db.users.findMany({key: 'subscribedToUserIds', inArray: user.id});
+      resolve: async (user: any, args: any, context: ContextValueType) => {
+        const usersBySubscribedToUserIds = context.loaders.usersBySubscribedToUserIds;
+        return await usersBySubscribedToUserIds.load(user.id);
       }
     },
     // these are users who are following the current user.
     subscribedToUser: {
       type: new GraphQLList(userType),
-      resolve: async (user: any, args: any, fastify: FastifyInstance) => {
-        return await fastify.db.users.findMany({key: 'id', equalsAnyOf: user.subscribedToUserIds});
+      resolve: async (user: any, args: any, context: ContextValueType) => {
+        const userById = context.loaders.userById;
+
+        return await userById.loadMany(user.subscribedToUserIds);
       }
     }
   })

--- a/src/routes/graphql/user/userUnsubscribeFromInput.ts
+++ b/src/routes/graphql/user/userUnsubscribeFromInput.ts
@@ -1,0 +1,11 @@
+import { GraphQLInputObjectType, GraphQLNonNull, GraphQLID } from 'graphql';
+
+const userUnsubscribeFromInput = new GraphQLInputObjectType({
+  name: 'UserUnsubscribeFromInput',
+  fields: () => ({
+    currentUserId: { type: new GraphQLNonNull(GraphQLID) },
+    unsubscribeFromUserId: { type: new GraphQLNonNull(GraphQLID) },
+  })
+});
+
+export { userUnsubscribeFromInput };

--- a/src/routes/graphql/user/userUpdateInput.ts
+++ b/src/routes/graphql/user/userUpdateInput.ts
@@ -3,7 +3,6 @@ import {GraphQLString, GraphQLInputObjectType} from 'graphql';
 const userUpdateInput = new GraphQLInputObjectType({
   name: 'UserUpdateInput',
   fields: () => ({
-    // todo bug with setting null
     firstName: { type:  GraphQLString },
     lastName: { type: GraphQLString },
     email: { type: GraphQLString },

--- a/src/routes/graphql/user/userUpdateInput.ts
+++ b/src/routes/graphql/user/userUpdateInput.ts
@@ -1,0 +1,12 @@
+import {GraphQLString, GraphQLInputObjectType} from 'graphql';
+
+const userUpdateInput = new GraphQLInputObjectType({
+  name: 'UserUpdateInput',
+  fields: () => ({
+    firstName: { type:  GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+  })
+});
+
+export { userUpdateInput };

--- a/src/routes/graphql/user/userUpdateInput.ts
+++ b/src/routes/graphql/user/userUpdateInput.ts
@@ -1,4 +1,4 @@
-import {GraphQLString, GraphQLInputObjectType} from 'graphql';
+import { GraphQLString, GraphQLInputObjectType } from 'graphql';
 
 const userUpdateInput = new GraphQLInputObjectType({
   name: 'UserUpdateInput',

--- a/src/routes/graphql/user/userUpdateInput.ts
+++ b/src/routes/graphql/user/userUpdateInput.ts
@@ -3,6 +3,7 @@ import {GraphQLString, GraphQLInputObjectType} from 'graphql';
 const userUpdateInput = new GraphQLInputObjectType({
   name: 'UserUpdateInput',
   fields: () => ({
+    // todo bug with setting null
     firstName: { type:  GraphQLString },
     lastName: { type: GraphQLString },
     email: { type: GraphQLString },

--- a/src/routes/graphql/user/usersQuery.ts
+++ b/src/routes/graphql/user/usersQuery.ts
@@ -1,7 +1,7 @@
-import {GraphQLList} from "graphql";
-import {userType} from "./userType";
-import {ContextValueType} from "../ContextValueType";
-import {UserEntity} from "../../../utils/DB/entities/DBUsers";
+import { GraphQLList } from 'graphql';
+import { userType } from './userType';
+import { ContextValueType } from '../ContextValueType';
+import { UserEntity } from '../../../utils/DB/entities/DBUsers';
 
 const usersQuery = {
   type: new GraphQLList(userType),

--- a/src/routes/graphql/user/usersQuery.ts
+++ b/src/routes/graphql/user/usersQuery.ts
@@ -1,11 +1,16 @@
 import {GraphQLList} from "graphql";
 import {userType} from "./userType";
-import {FastifyInstance} from "fastify";
+import {ContextValueType} from "../ContextValueType";
+import {UserEntity} from "../../../utils/DB/entities/DBUsers";
 
 const usersQuery = {
   type: new GraphQLList(userType),
-  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
-    return await fastify.db.users.findMany();
+  resolve: async (_: any, args: any, context: ContextValueType) => {
+    const allUsers: UserEntity[] = await context.fastify.db.users.findMany();
+
+    context.loaders.populateUserCache(allUsers);
+
+    return allUsers;
   }
 };
 

--- a/src/routes/graphql/user/usersQuery.ts
+++ b/src/routes/graphql/user/usersQuery.ts
@@ -14,4 +14,4 @@ const usersQuery = {
   }
 };
 
-export { usersQuery}
+export { usersQuery };

--- a/src/routes/graphql/user/usersQuery.ts
+++ b/src/routes/graphql/user/usersQuery.ts
@@ -1,0 +1,12 @@
+import {GraphQLList} from "graphql";
+import {userType} from "./userType";
+import {FastifyInstance} from "fastify";
+
+const usersQuery = {
+  type: new GraphQLList(userType),
+  resolve: async (_: any, args: any, fastify: FastifyInstance) => {
+    return await fastify.db.users.findMany();
+  }
+};
+
+export { usersQuery}

--- a/src/routes/graphql/validateQuery.ts
+++ b/src/routes/graphql/validateQuery.ts
@@ -1,7 +1,7 @@
-import {FastifyInstance} from "fastify";
-import {GraphQLError} from "graphql/error/GraphQLError";
-import {DocumentNode, GraphQLSchema, parse, Source, validate} from "graphql/index";
-import * as depthLimit from "graphql-depth-limit";
+import { FastifyInstance } from 'fastify';
+import { GraphQLError } from 'graphql/error/GraphQLError';
+import { DocumentNode, GraphQLSchema, parse, Source, validate } from 'graphql/index';
+import * as depthLimit from 'graphql-depth-limit';
 
 const GRAPHQL_QUERY_DEPTH_LIMIT = 6;
 

--- a/src/routes/graphql/validateQuery.ts
+++ b/src/routes/graphql/validateQuery.ts
@@ -1,0 +1,25 @@
+import {FastifyInstance} from "fastify";
+import {GraphQLError} from "graphql/error/GraphQLError";
+import {DocumentNode, GraphQLSchema, parse, Source, validate} from "graphql/index";
+import * as depthLimit from "graphql-depth-limit";
+
+const GRAPHQL_QUERY_DEPTH_LIMIT = 6;
+
+const validateQuery = (schema: GraphQLSchema, queryAsString: string, fastify: FastifyInstance): ReadonlyArray<GraphQLError> => {
+  let documentAST: DocumentNode;
+
+  try {
+    documentAST = parse(new Source(queryAsString, 'GraphQL request'));
+  } catch (syntaxError: any) {
+    // Return 400: Bad Request if any syntax errors exist.
+    throw fastify.httpErrors.badRequest(syntaxError.message);
+  }
+
+  const validationErrors = validate(schema, documentAST, [
+    depthLimit(GRAPHQL_QUERY_DEPTH_LIMIT)
+  ]);
+
+  return validationErrors;
+};
+
+export { validateQuery };

--- a/src/routes/graphql/validateQuery.ts
+++ b/src/routes/graphql/validateQuery.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { GraphQLError } from 'graphql/error/GraphQLError';
 import { DocumentNode, GraphQLSchema, parse, Source, validate } from 'graphql/index';
 import * as depthLimit from 'graphql-depth-limit';
+const { specifiedRules } = require('graphql/validation')
 
 const GRAPHQL_QUERY_DEPTH_LIMIT = 6;
 
@@ -16,6 +17,7 @@ const validateQuery = (schema: GraphQLSchema, queryAsString: string, fastify: Fa
   }
 
   const validationErrors = validate(schema, documentAST, [
+    ...specifiedRules,
     depthLimit(GRAPHQL_QUERY_DEPTH_LIMIT)
   ]);
 

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -3,12 +3,15 @@ import { idParamSchema } from '../../utils/reusedSchemas';
 import { changeMemberTypeBodySchema } from './schema';
 import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 
+// TODO integrity is not checked!!!!!!!!!!!!!
+
+
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    MemberTypeEntity[]
-  > {});
+  fastify.get('/', async function (request, reply): Promise<MemberTypeEntity[]> {
+        return await fastify.db.memberTypes.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +20,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+        const { id } = request.params;
+        const memberType = await fastify.db.memberTypes.findOne(id);
+
+        if (memberType === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        return memberType;
+    }
   );
 
   fastify.patch(
@@ -28,7 +40,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+        const { id } = request.params;
+        const memberType = await fastify.db.memberTypes.findOne(id);
+
+        if (memberType === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        const updatedMemberType = await fastify.db.memberTypes.change(id, request.body);
+
+        return updatedMemberType!;
+    }
   );
 };
 

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -1,10 +1,7 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { changeMemberTypeBodySchema } from './schema';
-import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
-
-// TODO integrity is not checked!!!!!!!!!!!!!
-
+import { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -22,7 +22,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply): Promise<MemberTypeEntity> {
         const { id } = request.params;
-        const memberType = await fastify.db.memberTypes.findOne(id);
+        const memberType = await fastify.db.memberTypes.findOne({key: 'id', equals: id});
 
         if (memberType === null) {
             throw fastify.httpErrors.notFound();
@@ -41,16 +41,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<MemberTypeEntity> {
-        const { id } = request.params;
-        const memberType = await fastify.db.memberTypes.findOne(id);
+      const { id } = request.params;
+      const memberType = await fastify.db.memberTypes.findOne({key: 'id', equals: id});
 
-        if (memberType === null) {
-            throw fastify.httpErrors.notFound();
-        }
+      if (memberType === null) {
+        throw fastify.httpErrors.badRequest();
+      }
 
-        const updatedMemberType = await fastify.db.memberTypes.change(id, request.body);
+      const updatedMemberType = await fastify.db.memberTypes.change(id, request.body);
 
-        return updatedMemberType!;
+      return updatedMemberType!;
     }
   );
 };

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -15,14 +15,14 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       '/:id',
       {schema: {params: idParamSchema}},
     async function (request, reply): Promise<PostEntity> {
-        const { id } = request.params;
-        const post = await fastify.db.posts.findOne(id);
+      const { id } = request.params;
+      const post = await fastify.db.posts.findOne({key: 'id', equals: id});
 
-        if (post === null) {
-            throw fastify.httpErrors.notFound();
-        }
+      if (post === null) {
+        throw fastify.httpErrors.notFound();
+      }
 
-        return post;
+      return post;
     }
   );
 
@@ -34,24 +34,21 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<PostEntity> {
-        const { userId } = request.body;
+      const { userId } = request.body;
 
-        if (!isUuid(userId)) {
-            throw fastify.httpErrors.badRequest();
-        }
+      if (!isUuid(userId)) {
+        throw fastify.httpErrors.badRequest();
+      }
 
-        const user = await fastify.db.users.findOne(userId);
+      const user = await fastify.db.users.findOne({key: 'id', equals: userId});
 
-        if (user === null) {
-            throw fastify.httpErrors.badRequest();
-        }
+      if (user === null) {
+        throw fastify.httpErrors.badRequest();
+      }
 
-        const post = await fastify.db.posts.create(request.body);
+      const post = await fastify.db.posts.create(request.body);
 
-        user!.postIds.push(post.id);
-        await fastify.db.users.change(userId, user!);
-
-        return post;
+      return post;
     }
   );
 
@@ -63,26 +60,21 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<PostEntity> {
-        const { id } = request.params;
-        const post = await fastify.db.posts.findOne(id);
+      const { id } = request.params;
 
-        if (post === null) {
-            throw fastify.httpErrors.notFound();
-        }
+      if (!isUuid(id)) {
+        throw fastify.httpErrors.badRequest();
+      }
 
-        await fastify.db.posts.delete(id);
+      const post = await fastify.db.posts.findOne({key: 'id', equals: id});
 
-        const user = await fastify.db.users.findOne(post.userId);
+      if (post === null) {
+        throw fastify.httpErrors.notFound();
+      }
 
-        if (user === null) {
-            throw fastify.httpErrors.internalServerError();
-        }
+      await fastify.db.posts.delete(id);
 
-        user.postIds = user.postIds.filter((postId) => postId !== id);
-
-        await fastify.db.users.change(post.userId, user);
-
-        return post;
+      return post;
     }
   );
 
@@ -95,16 +87,21 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<PostEntity> {
-        const { id } = request.params;
-        const post = await fastify.db.posts.findOne(id);
+      const { id } = request.params;
 
-        if (post === null) {
-            throw fastify.httpErrors.notFound();
-        }
+      if (!isUuid(id)) {
+        throw fastify.httpErrors.badRequest();
+      }
 
-        const changed = await fastify.db.posts.change(id, request.body);
+      const post = await fastify.db.posts.findOne({key: 'id', equals: id});
 
-        return changed!;
+      if (post === null) {
+        throw fastify.httpErrors.notFound();
+      }
+
+      const changed = await fastify.db.posts.change(id, request.body);
+
+      return changed!;
     }
   );
 };

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -2,20 +2,28 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { createPostBodySchema, changePostBodySchema } from './schema';
 import type { PostEntity } from '../../utils/DB/entities/DBPosts';
+import { isUuid } from '../../utils/isUuid';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {
+      return await fastify.db.posts.findMany();
+  });
 
   fastify.get(
-    '/:id',
-    {
-      schema: {
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<PostEntity> {}
+      '/:id',
+      {schema: {params: idParamSchema}},
+    async function (request, reply): Promise<PostEntity> {
+        const { id } = request.params;
+        const post = await fastify.db.posts.findOne(id);
+
+        if (post === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        return post;
+    }
   );
 
   fastify.post(
@@ -25,7 +33,26 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createPostBodySchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+        const { userId } = request.body;
+
+        if (!isUuid(userId)) {
+            throw fastify.httpErrors.badRequest();
+        }
+
+        const user = await fastify.db.users.findOne(userId);
+
+        if (user === null) {
+            throw fastify.httpErrors.badRequest();
+        }
+
+        const post = await fastify.db.posts.create(request.body);
+
+        user!.postIds.push(post.id);
+        await fastify.db.users.change(userId, user!);
+
+        return post;
+    }
   );
 
   fastify.delete(
@@ -35,7 +62,28 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+        const { id } = request.params;
+        const post = await fastify.db.posts.findOne(id);
+
+        if (post === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        await fastify.db.posts.delete(id);
+
+        const user = await fastify.db.users.findOne(post.userId);
+
+        if (user === null) {
+            throw fastify.httpErrors.internalServerError();
+        }
+
+        user.postIds = user.postIds.filter((postId) => postId !== id);
+
+        await fastify.db.users.change(post.userId, user);
+
+        return post;
+    }
   );
 
   fastify.patch(
@@ -46,7 +94,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+        const { id } = request.params;
+        const post = await fastify.db.posts.findOne(id);
+
+        if (post === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        const changed = await fastify.db.posts.change(id, request.body);
+
+        return changed!;
+    }
   );
 };
 

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -2,13 +2,14 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { createProfileBodySchema, changeProfileBodySchema } from './schema';
 import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import {removeArrayItem} from "../../utils/removeArrayItem";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    ProfileEntity[]
-  > {});
+  fastify.get('/', async function (request, reply): Promise<ProfileEntity[]> {
+        return await fastify.db.profiles.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +18,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+        const { id } = request.params;
+        const profile = await fastify.db.profiles.findOne(id);
+
+        if (profile === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        return profile;
+    }
   );
 
   fastify.post(
@@ -27,7 +37,25 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createProfileBodySchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+        const { userId } = request.body;
+
+        const user = await fastify.db.users.findOne(userId);
+
+        if (user === null) {
+            throw fastify.httpErrors.badRequest();
+        }
+
+        if (user.profileId !== null) {
+            throw fastify.httpErrors.badRequest();
+        }
+
+        const profile = await fastify.db.profiles.create(request.body);
+
+        await fastify.db.users.change(userId, { profileId: profile.id });
+
+        return profile;
+    }
   );
 
   fastify.delete(
@@ -37,7 +65,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+        const { id } = request.params;
+        const profile = await fastify.db.profiles.findOne(id);
+
+        if (profile === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        await fastify.db.profiles.delete(id);
+
+        const user = await fastify.db.users.findOne(profile.userId);
+
+        if (user !== null) {
+            await fastify.db.users.change(user.id, { profileId: null });
+        }
+
+        return profile;
+    }
   );
 
   fastify.patch(
@@ -48,7 +93,45 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+        const { id } = request.params;
+        const profile = await fastify.db.profiles.findOne(id);
+
+        if (profile === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        const previousMemberTypeId = profile.memberTypeId;
+        const newMemberTypeId = request.body.memberTypeId;
+
+        const updatedProfile = await fastify.db.profiles.change(id, request.body);
+
+        if (previousMemberTypeId !== undefined
+            && newMemberTypeId !== undefined
+            && previousMemberTypeId !== newMemberTypeId) {
+            const previousMemberType = await fastify.db.memberTypes.findOne(previousMemberTypeId);
+
+            if (previousMemberType === null) {
+                throw fastify.httpErrors.internalServerError();
+            }
+
+            removeArrayItem(previousMemberType.profileIds, id);
+
+            await fastify.db.memberTypes.change(previousMemberTypeId, previousMemberType);
+
+            const newMemberType = await fastify.db.memberTypes.findOne(newMemberTypeId);
+
+            if (newMemberType === null) {
+                throw fastify.httpErrors.internalServerError();
+            }
+
+            newMemberType.profileIds.push(id);
+
+            await fastify.db.memberTypes.change(newMemberTypeId, newMemberType);
+        }
+
+        return updatedProfile!;
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -6,11 +6,14 @@ import {
   subscribeBodySchema,
 } from './schemas';
 import type { UserEntity } from '../../utils/DB/entities/DBUsers';
+import {removeArrayItem} from "../../utils/removeArrayItem";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {
+    return await fastify.db.users.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -19,7 +22,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+        const { id } = request.params;
+        const user = await fastify.db.users.findOne(id);
+
+        if (user === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        return user;
+    }
   );
 
   fastify.post(
@@ -29,7 +41,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createUserBodySchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+        const user = await fastify.db.users.create(request.body);
+
+        return user;
+    }
   );
 
   fastify.delete(
@@ -39,7 +55,38 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+        const { id } = request.params;
+        const user = await fastify.db.users.findOne(id);
+
+        if (user === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        for (const subscribedToUserId of user.userSubscribedToIds) {
+            const subscribedToUser = await fastify.db.users.findOne(subscribedToUserId);
+
+            if (subscribedToUser === null) {
+                throw fastify.httpErrors.internalServerError();
+            }
+
+            removeArrayItem(subscribedToUser.subscribedToUserIds, id);
+
+            await fastify.db.users.change(subscribedToUser.id, subscribedToUser);
+        }
+
+        for (const postId of user.postIds) {
+            await fastify.db.posts.delete(postId);
+        }
+
+        if (user.profileId !== null) {
+            await fastify.db.profiles.delete(user.profileId);
+        }
+
+        await fastify.db.users.delete(id);
+
+        return user;
+    }
   );
 
   fastify.post(
@@ -50,7 +97,34 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+        const { id } = request.params;
+        const { userId: userIdSubscribeTo } = request.body;
+
+        const user = await fastify.db.users.findOne(id);
+
+        if (user === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        const userSubscribeTo = await fastify.db.users.findOne(userIdSubscribeTo);
+
+        if (userSubscribeTo === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        if (user.userSubscribedToIds.includes(userIdSubscribeTo)) {
+            throw fastify.httpErrors.badRequest();
+        }
+
+        user.userSubscribedToIds.push(userIdSubscribeTo);
+        userSubscribeTo.subscribedToUserIds.push(id);
+
+        await fastify.db.users.change(id, user);
+        await fastify.db.users.change(userIdSubscribeTo, userSubscribeTo);
+
+        return user;
+    }
   );
 
   fastify.post(
@@ -61,7 +135,34 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+        const { id } = request.params;
+        const { userId: userIdUnsubscribeFrom } = request.body;
+
+        const user = await fastify.db.users.findOne(id);
+
+        if (user === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        const userUnsubscribeFrom = await fastify.db.users.findOne(userIdUnsubscribeFrom);
+
+        if (userUnsubscribeFrom === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        if (!user.userSubscribedToIds.includes(userIdUnsubscribeFrom)) {
+            throw fastify.httpErrors.badRequest();
+        }
+
+        removeArrayItem(user.userSubscribedToIds, userIdUnsubscribeFrom);
+        removeArrayItem(userUnsubscribeFrom.subscribedToUserIds, id);
+
+        await fastify.db.users.change(id, user);
+        await fastify.db.users.change(userIdUnsubscribeFrom, userUnsubscribeFrom);
+
+        return user;
+    }
   );
 
   fastify.patch(
@@ -72,7 +173,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+        const { id } = request.params;
+        const user = await fastify.db.users.findOne(id);
+
+        if (user === null) {
+            throw fastify.httpErrors.notFound();
+        }
+
+        const changedUser = await fastify.db.users.change(id, request.body);
+
+        return changedUser!;
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -105,7 +105,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply): Promise<UserEntity> {
       const { id } = request.params;
-      const { userId: userIdSubscribeFrom } = request.body;
+      const { userId: userIdSubscribeTo } = request.body;
 
       const user = await fastify.db.users.findOne({key: 'id', equals: id});
 
@@ -113,19 +113,19 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         throw fastify.httpErrors.notFound();
       }
 
-      const userSubscribeFrom = await fastify.db.users.findOne({key: 'id', equals: userIdSubscribeFrom});
+      const userSubscribeTo = await fastify.db.users.findOne({key: 'id', equals: userIdSubscribeTo});
 
-      if (userSubscribeFrom === null) {
+      if (userSubscribeTo === null) {
         throw fastify.httpErrors.notFound();
       }
 
-      if (userSubscribeFrom.subscribedToUserIds.includes(id)) {
+      if (userSubscribeTo.subscribedToUserIds.includes(id)) {
         throw fastify.httpErrors.badRequest();
       }
 
-      userSubscribeFrom.subscribedToUserIds.push(id);
+      userSubscribeTo.subscribedToUserIds.push(id);
 
-      await fastify.db.users.change(userIdSubscribeFrom, userSubscribeFrom);
+      await fastify.db.users.change(userIdSubscribeTo, userSubscribeTo);
 
       return user;
     }
@@ -155,6 +155,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         throw fastify.httpErrors.notFound();
       }
 
+      // `subscribedToUserIds` - this is who subscribed to `user` - followers
       if (!user.subscribedToUserIds.includes(userIdUnsubscribeFrom)) {
         throw fastify.httpErrors.badRequest();
       }

--- a/src/utils/DB/DB.ts
+++ b/src/utils/DB/DB.ts
@@ -13,6 +13,7 @@ export default class DB {
   constructor() {
     const deepCopyResultTrap: ProxyHandler<any> = {
       get: (target, prop) => {
+        // console.log('DB', target.constructor.name, prop)
         if (typeof target[prop] === 'function') {
           return (...args: any[]) => {
             const result = target[prop](...args);

--- a/src/utils/isUuid.ts
+++ b/src/utils/isUuid.ts
@@ -1,0 +1,9 @@
+const uuidRegex = new RegExp(
+    '^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$'
+);
+
+function isUuid(uuid: string): boolean {
+    return uuidRegex.test(uuid);
+}
+
+export { isUuid };

--- a/src/utils/removeArrayItem.ts
+++ b/src/utils/removeArrayItem.ts
@@ -1,0 +1,10 @@
+// remove item from array by value
+const removeArrayItem = (array: unknown[], value: unknown) => {
+    const index = array.indexOf(value);
+
+    if (index !== -1) {
+        array.splice(index, 1);
+    }
+}
+
+export { removeArrayItem };

--- a/test/routes/users.test.ts
+++ b/test/routes/users.test.ts
@@ -1,163 +1,88 @@
 import { test } from 'tap';
 import { build } from '../helper';
-import { createUser, createPost, createProfile } from '../utils/requests';
+import {
+  createUser,
+  createPost,
+  createProfile,
+  getUser,
+  getProfile,
+  getPost,
+} from '../utils/requests';
 
 test('users', async (t) => {
   const app = await build(t);
 
+  await t.test('GET /users/:id => failure; fake params.id', async (t) => {
+    const { res: resReceivedUser } = await getUser(app, 'fakeId');
+
+    t.ok(resReceivedUser.statusCode === 404);
+  });
+
   await t.test('POST /users => success', async (t) => {
-    const { body: user } = await createUser(app);
+    const { body: user1 } = await createUser(app);
+    const { body: receivedUser1 } = await getUser(app, user1.id);
 
-    const res_findUser = await app.inject({
-      url: `/users/${user.id}`,
-    });
-
-    t.ok(res_findUser.statusCode < 300);
+    t.ok(receivedUser1.id === user1.id);
   });
 
   await t.test('PATCH /users/:id => failure; fake params.id', async (t) => {
-    const res_patchUser = await app.inject({
+    const responsePatch = await app.inject({
       url: `/users/fakeId`,
       method: 'PATCH',
       payload: {},
     });
 
-    t.ok(res_patchUser.statusCode > 300);
+    t.ok(responsePatch.statusCode === 400);
   });
 
   await t.test('PATCH /users/:id => success', async (t) => {
-    let { body: user } = await createUser(app);
+    const { body: user1 } = await createUser(app);
 
     const changedEmail = 'qwe@gmail.com';
+    await app.inject({
+      url: `/users/${user1.id}`,
+      method: 'PATCH',
+      payload: {
+        email: changedEmail,
+      },
+    });
 
-    user = await app
-      .inject({
-        url: `/users/${user.id}`,
-        method: 'PATCH',
-        payload: {
-          email: changedEmail,
-        },
-      })
-      .then((r: any) => r.json(0));
+    const { body: receivedUser } = await getUser(app, user1.id);
 
-    t.ok(user.email === changedEmail);
+    t.ok(receivedUser.email === changedEmail);
   });
 
-  await t.test(
-    'POST /users/:id/subscribeTo => failure; fake params.id',
-    async (t) => {
-      const res_subscribeTo = await app.inject({
-        url: `/users/fakeId/subscribeTo`,
-        method: 'POST',
-        payload: {
-          userId: 'fakeId',
-        },
-      });
-
-      t.ok(res_subscribeTo.statusCode > 300);
-    }
-  );
-
-  await t.test(
-    'POST /users/:id/subscribeTo => failure; fake body.userId',
-    async (t) => {
-      const { body: user } = await createUser(app);
-
-      const res_subscribeTo = await app.inject({
-        url: `/users/${user.id}/subscribeTo`,
-        method: 'POST',
-        payload: {
-          userId: 'fakeId',
-        },
-      });
-
-      t.ok(res_subscribeTo.statusCode > 300);
-    }
-  );
-
-  await t.test(
-    'POST /users/:id/subscribeTo => failure; body.userId is already a subscriber',
-    async (t) => {
-      const { body: user1 } = await createUser(app);
-      const { body: user2 } = await createUser(app);
-
-      await app.inject({
-        url: `/users/${user1.id}/subscribeTo`,
-        method: 'POST',
-        payload: {
-          userId: user2.id,
-        },
-      });
-
-      const res_subscribeTo = await app.inject({
-        url: `/users/${user1.id}/subscribeTo`,
-        method: 'POST',
-        payload: {
-          userId: user2.id,
-        },
-      });
-
-      t.ok(res_subscribeTo.statusCode > 300);
-    }
-  );
-
   await t.test('POST /users/:id/subscribeTo => success', async (t) => {
-    let { body: user1 } = await createUser(app);
-    let { body: user2 } = await createUser(app);
-    let { body: user3 } = await createUser(app);
+    const { body: user1 } = await createUser(app);
+    const { body: user2 } = await createUser(app);
+    const { body: user3 } = await createUser(app);
 
-    user1 = await app
-      .inject({
-        url: `/users/${user1.id}/subscribeTo`,
-        method: 'POST',
-        payload: {
-          userId: user2.id,
-        },
-      })
-      .then((r: any) => r.json());
+    await app.inject({
+      url: `/users/${user1.id}/subscribeTo`,
+      method: 'POST',
+      payload: {
+        userId: user3.id,
+      },
+    });
+    await app.inject({
+      url: `/users/${user2.id}/subscribeTo`,
+      method: 'POST',
+      payload: {
+        userId: user3.id,
+      },
+    });
 
+    const { body: receivedUser3 } = await getUser(app, user3.id);
     t.ok(
-      user1.userSubscribedToIds.includes(user2.id) &&
-        user1.userSubscribedToIds.length === 1,
-      'userSubscribedToIds should be updated'
-    );
-
-    user1 = await app
-      .inject({
-        url: `/users/${user1.id}/subscribeTo`,
-        method: 'POST',
-        payload: {
-          userId: user3.id,
-        },
-      })
-      .then((r: any) => r.json());
-    t.ok(
-      user1.userSubscribedToIds.includes(user3.id) &&
-        user1.userSubscribedToIds.length === 2,
-      'userSubscribedToIds should be updated'
-    );
-
-    user2 = await app
-      .inject({
-        url: `/users/${user2.id}`,
-      })
-      .then((r: any) => r.json());
-    user3 = await app
-      .inject({
-        url: `/users/${user3.id}`,
-      })
-      .then((r: any) => r.json());
-    t.ok(
-      user2.subscribedToUserIds.includes(user1.id) &&
-        user3.subscribedToUserIds.includes(user1.id),
-      'subscribedToUserIds should be updated'
+      receivedUser3.subscribedToUserIds.includes(user1.id) &&
+        receivedUser3.subscribedToUserIds.includes(user2.id)
     );
   });
 
   await t.test(
     'POST /users/:id/unsubscribeFrom => failure; fake params.id',
     async (t) => {
-      const res_unsubscribeFrom = await app.inject({
+      const responseUnsubscribeFrom = await app.inject({
         url: `/users/fakeId/unsubscribeFrom`,
         method: 'POST',
         payload: {
@@ -165,7 +90,7 @@ test('users', async (t) => {
         },
       });
 
-      t.ok(res_unsubscribeFrom.statusCode > 300);
+      t.ok(responseUnsubscribeFrom.statusCode === 400);
     }
   );
 
@@ -174,7 +99,7 @@ test('users', async (t) => {
     async (t) => {
       const { body: user1 } = await createUser(app);
 
-      const res_unsubscribeFrom = await app.inject({
+      const responseUnsubscribeFrom = await app.inject({
         url: `/users/${user1.id}/unsubscribeFrom`,
         method: 'POST',
         payload: {
@@ -182,7 +107,7 @@ test('users', async (t) => {
         },
       });
 
-      t.ok(res_unsubscribeFrom.statusCode > 300);
+      t.ok(responseUnsubscribeFrom.statusCode === 400);
     }
   );
 
@@ -192,7 +117,7 @@ test('users', async (t) => {
       const { body: user1 } = await createUser(app);
       const { body: user2 } = await createUser(app);
 
-      const res_unsubscribeFrom = await app.inject({
+      const responseUnsubscribeFrom = await app.inject({
         url: `/users/${user1.id}/unsubscribeFrom`,
         method: 'POST',
         payload: {
@@ -200,22 +125,15 @@ test('users', async (t) => {
         },
       });
 
-      t.ok(res_unsubscribeFrom.statusCode > 300);
+      t.ok(responseUnsubscribeFrom.statusCode === 400);
     }
   );
 
   await t.test('POST /users/:id/unsubscribeFrom => success', async (t) => {
-    let { body: user1 } = await createUser(app);
-    let { body: user2 } = await createUser(app);
-    let { body: user3 } = await createUser(app);
+    const { body: user1 } = await createUser(app);
+    const { body: user2 } = await createUser(app);
+    const { body: user3 } = await createUser(app);
 
-    await app.inject({
-      url: `/users/${user1.id}/subscribeTo`,
-      method: 'POST',
-      payload: {
-        userId: user2.id,
-      },
-    });
     await app.inject({
       url: `/users/${user1.id}/subscribeTo`,
       method: 'POST',
@@ -223,69 +141,44 @@ test('users', async (t) => {
         userId: user3.id,
       },
     });
+    await app.inject({
+      url: `/users/${user2.id}/subscribeTo`,
+      method: 'POST',
+      payload: {
+        userId: user3.id,
+      },
+    });
+    await app.inject({
+      url: `/users/${user1.id}/unsubscribeFrom`,
+      method: 'POST',
+      payload: {
+        userId: user3.id,
+      },
+    });
 
-    user1 = await app
-      .inject({
-        url: `/users/${user1.id}/unsubscribeFrom`,
-        method: 'POST',
-        payload: {
-          userId: user2.id,
-        },
-      })
-      .then((r: any) => r.json());
+    const { body: receivedUser3 } = await getUser(app, user3.id);
     t.ok(
-      !user1.userSubscribedToIds.includes(user2.id) &&
-        user1.userSubscribedToIds.length === 1,
-      'userSubscribedToIds should be updated'
-    );
-    user1 = await app
-      .inject({
-        url: `/users/${user1.id}/unsubscribeFrom`,
-        method: 'POST',
-        payload: {
-          userId: user3.id,
-        },
-      })
-      .then((r: any) => r.json());
-    t.ok(
-      !user1.userSubscribedToIds.includes(user3.id) &&
-        user1.userSubscribedToIds.length === 0,
-      'userSubscribedToIds should be updated'
-    );
-
-    user2 = await app
-      .inject({
-        url: `/users/${user2.id}`,
-      })
-      .then((r: any) => r.json());
-    user3 = await app
-      .inject({
-        url: `/users/${user3.id}`,
-      })
-      .then((r: any) => r.json());
-    t.ok(
-      !user2.subscribedToUserIds.includes(user1.id) &&
-        !user3.subscribedToUserIds.includes(user1.id),
-      'subscribedToUserIds should be updated'
+      receivedUser3.subscribedToUserIds.includes(user2.id) &&
+        !receivedUser3.subscribedToUserIds.includes(user1.id)
     );
   });
 
   await t.test('DELETE /users/:id => failure; fake params.id', async (t) => {
-    const res_deleteUser = await app.inject({
+    const responseDeleteUser = await app.inject({
       url: `/users/fakeId`,
       method: 'DELETE',
     });
 
-    t.ok(res_deleteUser.statusCode > 300);
+    t.ok(responseDeleteUser.statusCode === 400);
   });
 
   await t.test(
     'DELETE /users/:id => success; user with relations',
     async (t) => {
       const { body: user1 } = await createUser(app);
-      let { body: user2 } = await createUser(app);
-      const { body: post } = await createPost(app, user1.id);
-      const { body: profile } = await createProfile(app, user1.id, 'basic');
+      const { body: user2 } = await createUser(app);
+      const { body: post1 } = await createPost(app, user1.id);
+      const { body: profile1 } = await createProfile(app, user1.id, 'basic');
 
       await app.inject({
         url: `/users/${user1.id}/subscribeTo`,
@@ -295,36 +188,22 @@ test('users', async (t) => {
         },
       });
 
-      await app
-        .inject({
-          url: `/users/${user1.id}`,
-          method: 'DELETE',
-        })
-        .then((r: any) => r.json());
-
-      const res_findUser1 = await app.inject({
+      await app.inject({
         url: `/users/${user1.id}`,
+        method: 'DELETE',
       });
-      t.ok(res_findUser1.statusCode > 300, 'user must be deleted');
 
-      user2 = await app
-        .inject({
-          url: `/users/${user2.id}`,
-        })
-        .then((r: any) => r.json());
-      t.ok(
-        !user2.subscribedToUserIds.includes(user1.id),
-        'no links to the deleted user in subscribedToUserIds'
-      );
+      const { res: resReceivedUser1 } = await getUser(app, user1.id);
+      t.ok(resReceivedUser1.statusCode === 404);
 
-      const res_findPost = await app.inject({
-        url: `/posts/${post.id}`,
-      });
-      const res_findProfile = await app.inject({
-        url: `/profiles/${profile.id}`,
-      });
-      t.ok(res_findPost.statusCode > 300, 'post must be deleted');
-      t.ok(res_findProfile.statusCode > 300, 'profile must be deleted');
+      const { body: receivedUser2 } = await getUser(app, user2.id);
+      t.ok(!receivedUser2.subscribedToUserIds.includes(user1.id));
+
+      const { res: resReceivedProfile1 } = await getProfile(app, profile1.id);
+      t.ok(resReceivedProfile1.statusCode === 404);
+
+      const { res: resReceivedPost1 } = await getPost(app, post1.id);
+      t.ok(resReceivedPost1.statusCode === 404);
     }
   );
 });

--- a/test/routes/users.test.ts
+++ b/test/routes/users.test.ts
@@ -1,184 +1,85 @@
 import { test } from 'tap';
 import { build } from '../helper';
-import {
-  createUser,
-  createPost,
-  createProfile,
-  getUser,
-  getProfile,
-  getPost,
-} from '../utils/requests';
+import { createUser, createPost, createProfile } from '../utils/requests';
 
 test('users', async (t) => {
   const app = await build(t);
 
-  await t.test('GET /users/:id => failure; fake params.id', async (t) => {
-    const { res: resReceivedUser } = await getUser(app, 'fakeId');
-
-    t.ok(resReceivedUser.statusCode === 404);
-  });
-
   await t.test('POST /users => success', async (t) => {
-    const { body: user1 } = await createUser(app);
-    const { body: receivedUser1 } = await getUser(app, user1.id);
+    const { body: user } = await createUser(app);
 
-    t.ok(receivedUser1.id === user1.id);
+    const res_findUser = await app.inject({
+      url: `/users/${user.id}`,
+    });
+
+    t.ok(res_findUser.statusCode < 300);
   });
 
   await t.test('PATCH /users/:id => failure; fake params.id', async (t) => {
-    const responsePatch = await app.inject({
+    const res_patchUser = await app.inject({
       url: `/users/fakeId`,
       method: 'PATCH',
       payload: {},
     });
 
-    t.ok(responsePatch.statusCode === 400);
+    t.ok(res_patchUser.statusCode > 300);
   });
 
   await t.test('PATCH /users/:id => success', async (t) => {
-    const { body: user1 } = await createUser(app);
+    let { body: user } = await createUser(app);
 
     const changedEmail = 'qwe@gmail.com';
-    await app.inject({
-      url: `/users/${user1.id}`,
-      method: 'PATCH',
-      payload: {
-        email: changedEmail,
-      },
-    });
 
-    const { body: receivedUser } = await getUser(app, user1.id);
+    user = await app
+      .inject({
+        url: `/users/${user.id}`,
+        method: 'PATCH',
+        payload: {
+          email: changedEmail,
+        },
+      })
+      .then((r: any) => r.json(0));
 
-    t.ok(receivedUser.email === changedEmail);
-  });
-
-  await t.test('POST /users/:id/subscribeTo => success', async (t) => {
-    const { body: user1 } = await createUser(app);
-    const { body: user2 } = await createUser(app);
-    const { body: user3 } = await createUser(app);
-
-    await app.inject({
-      url: `/users/${user1.id}/subscribeTo`,
-      method: 'POST',
-      payload: {
-        userId: user3.id,
-      },
-    });
-    await app.inject({
-      url: `/users/${user2.id}/subscribeTo`,
-      method: 'POST',
-      payload: {
-        userId: user3.id,
-      },
-    });
-
-    const { body: receivedUser3 } = await getUser(app, user3.id);
-    t.ok(
-      receivedUser3.subscribedToUserIds.includes(user1.id) &&
-        receivedUser3.subscribedToUserIds.includes(user2.id)
-    );
+    t.ok(user.email === changedEmail);
   });
 
   await t.test(
-    'POST /users/:id/unsubscribeFrom => failure; fake params.id',
+    'POST /users/:id/subscribeTo => failure; fake params.id',
     async (t) => {
-      const responseUnsubscribeFrom = await app.inject({
-        url: `/users/fakeId/unsubscribeFrom`,
+      const res_subscribeTo = await app.inject({
+        url: `/users/fakeId/subscribeTo`,
         method: 'POST',
         payload: {
           userId: 'fakeId',
         },
       });
 
-      t.ok(responseUnsubscribeFrom.statusCode === 400);
+      t.ok(res_subscribeTo.statusCode > 300);
     }
   );
 
   await t.test(
-    'POST /users/:id/unsubscribeFrom => failure; fake body.userId',
+    'POST /users/:id/subscribeTo => failure; fake body.userId',
     async (t) => {
-      const { body: user1 } = await createUser(app);
+      const { body: user } = await createUser(app);
 
-      const responseUnsubscribeFrom = await app.inject({
-        url: `/users/${user1.id}/unsubscribeFrom`,
+      const res_subscribeTo = await app.inject({
+        url: `/users/${user.id}/subscribeTo`,
         method: 'POST',
         payload: {
           userId: 'fakeId',
         },
       });
 
-      t.ok(responseUnsubscribeFrom.statusCode === 400);
+      t.ok(res_subscribeTo.statusCode > 300);
     }
   );
 
   await t.test(
-    'POST /users/:id/unsubscribeFrom => failure; body.userId is valid but our user is not following him',
+    'POST /users/:id/subscribeTo => failure; body.userId is already a subscriber',
     async (t) => {
       const { body: user1 } = await createUser(app);
       const { body: user2 } = await createUser(app);
-
-      const responseUnsubscribeFrom = await app.inject({
-        url: `/users/${user1.id}/unsubscribeFrom`,
-        method: 'POST',
-        payload: {
-          userId: user2.id,
-        },
-      });
-
-      t.ok(responseUnsubscribeFrom.statusCode === 400);
-    }
-  );
-
-  await t.test('POST /users/:id/unsubscribeFrom => success', async (t) => {
-    const { body: user1 } = await createUser(app);
-    const { body: user2 } = await createUser(app);
-    const { body: user3 } = await createUser(app);
-
-    await app.inject({
-      url: `/users/${user1.id}/subscribeTo`,
-      method: 'POST',
-      payload: {
-        userId: user3.id,
-      },
-    });
-    await app.inject({
-      url: `/users/${user2.id}/subscribeTo`,
-      method: 'POST',
-      payload: {
-        userId: user3.id,
-      },
-    });
-    await app.inject({
-      url: `/users/${user1.id}/unsubscribeFrom`,
-      method: 'POST',
-      payload: {
-        userId: user3.id,
-      },
-    });
-
-    const { body: receivedUser3 } = await getUser(app, user3.id);
-    t.ok(
-      receivedUser3.subscribedToUserIds.includes(user2.id) &&
-        !receivedUser3.subscribedToUserIds.includes(user1.id)
-    );
-  });
-
-  await t.test('DELETE /users/:id => failure; fake params.id', async (t) => {
-    const responseDeleteUser = await app.inject({
-      url: `/users/fakeId`,
-      method: 'DELETE',
-    });
-
-    t.ok(responseDeleteUser.statusCode === 400);
-  });
-
-  await t.test(
-    'DELETE /users/:id => success; user with relations',
-    async (t) => {
-      const { body: user1 } = await createUser(app);
-      const { body: user2 } = await createUser(app);
-      const { body: post1 } = await createPost(app, user1.id);
-      const { body: profile1 } = await createProfile(app, user1.id, 'basic');
 
       await app.inject({
         url: `/users/${user1.id}/subscribeTo`,
@@ -188,22 +89,242 @@ test('users', async (t) => {
         },
       });
 
-      await app.inject({
-        url: `/users/${user1.id}`,
-        method: 'DELETE',
+      const res_subscribeTo = await app.inject({
+        url: `/users/${user1.id}/subscribeTo`,
+        method: 'POST',
+        payload: {
+          userId: user2.id,
+        },
       });
 
-      const { res: resReceivedUser1 } = await getUser(app, user1.id);
-      t.ok(resReceivedUser1.statusCode === 404);
+      t.ok(res_subscribeTo.statusCode > 300);
+    }
+  );
 
-      const { body: receivedUser2 } = await getUser(app, user2.id);
-      t.ok(!receivedUser2.subscribedToUserIds.includes(user1.id));
+  await t.test('POST /users/:id/subscribeTo => success', async (t) => {
+    let { body: user1 } = await createUser(app);
+    let { body: user2 } = await createUser(app);
+    let { body: user3 } = await createUser(app);
 
-      const { res: resReceivedProfile1 } = await getProfile(app, profile1.id);
-      t.ok(resReceivedProfile1.statusCode === 404);
+    user1 = await app
+      .inject({
+        url: `/users/${user1.id}/subscribeTo`,
+        method: 'POST',
+        payload: {
+          userId: user2.id,
+        },
+      })
+      .then((r: any) => r.json());
 
-      const { res: resReceivedPost1 } = await getPost(app, post1.id);
-      t.ok(resReceivedPost1.statusCode === 404);
+    t.ok(
+      user1.userSubscribedToIds.includes(user2.id) &&
+        user1.userSubscribedToIds.length === 1,
+      'userSubscribedToIds should be updated'
+    );
+
+    user1 = await app
+      .inject({
+        url: `/users/${user1.id}/subscribeTo`,
+        method: 'POST',
+        payload: {
+          userId: user3.id,
+        },
+      })
+      .then((r: any) => r.json());
+    t.ok(
+      user1.userSubscribedToIds.includes(user3.id) &&
+        user1.userSubscribedToIds.length === 2,
+      'userSubscribedToIds should be updated'
+    );
+
+    user2 = await app
+      .inject({
+        url: `/users/${user2.id}`,
+      })
+      .then((r: any) => r.json());
+    user3 = await app
+      .inject({
+        url: `/users/${user3.id}`,
+      })
+      .then((r: any) => r.json());
+    t.ok(
+      user2.subscribedToUserIds.includes(user1.id) &&
+        user3.subscribedToUserIds.includes(user1.id),
+      'subscribedToUserIds should be updated'
+    );
+  });
+
+  await t.test(
+    'POST /users/:id/unsubscribeFrom => failure; fake params.id',
+    async (t) => {
+      const res_unsubscribeFrom = await app.inject({
+        url: `/users/fakeId/unsubscribeFrom`,
+        method: 'POST',
+        payload: {
+          userId: 'fakeId',
+        },
+      });
+
+      t.ok(res_unsubscribeFrom.statusCode > 300);
+    }
+  );
+
+  await t.test(
+    'POST /users/:id/unsubscribeFrom => failure; fake body.userId',
+    async (t) => {
+      const { body: user1 } = await createUser(app);
+
+      const res_unsubscribeFrom = await app.inject({
+        url: `/users/${user1.id}/unsubscribeFrom`,
+        method: 'POST',
+        payload: {
+          userId: 'fakeId',
+        },
+      });
+
+      t.ok(res_unsubscribeFrom.statusCode > 300);
+    }
+  );
+
+  await t.test(
+    'POST /users/:id/unsubscribeFrom => failure; body.userId is valid but our user is not following him',
+    async (t) => {
+      const { body: user1 } = await createUser(app);
+      const { body: user2 } = await createUser(app);
+
+      const res_unsubscribeFrom = await app.inject({
+        url: `/users/${user1.id}/unsubscribeFrom`,
+        method: 'POST',
+        payload: {
+          userId: user2.id,
+        },
+      });
+
+      t.ok(res_unsubscribeFrom.statusCode > 300);
+    }
+  );
+
+  await t.test('POST /users/:id/unsubscribeFrom => success', async (t) => {
+    let { body: user1 } = await createUser(app);
+    let { body: user2 } = await createUser(app);
+    let { body: user3 } = await createUser(app);
+
+    await app.inject({
+      url: `/users/${user1.id}/subscribeTo`,
+      method: 'POST',
+      payload: {
+        userId: user2.id,
+      },
+    });
+    await app.inject({
+      url: `/users/${user1.id}/subscribeTo`,
+      method: 'POST',
+      payload: {
+        userId: user3.id,
+      },
+    });
+
+    user1 = await app
+      .inject({
+        url: `/users/${user1.id}/unsubscribeFrom`,
+        method: 'POST',
+        payload: {
+          userId: user2.id,
+        },
+      })
+      .then((r: any) => r.json());
+    t.ok(
+      !user1.userSubscribedToIds.includes(user2.id) &&
+        user1.userSubscribedToIds.length === 1,
+      'userSubscribedToIds should be updated'
+    );
+    user1 = await app
+      .inject({
+        url: `/users/${user1.id}/unsubscribeFrom`,
+        method: 'POST',
+        payload: {
+          userId: user3.id,
+        },
+      })
+      .then((r: any) => r.json());
+    t.ok(
+      !user1.userSubscribedToIds.includes(user3.id) &&
+        user1.userSubscribedToIds.length === 0,
+      'userSubscribedToIds should be updated'
+    );
+
+    user2 = await app
+      .inject({
+        url: `/users/${user2.id}`,
+      })
+      .then((r: any) => r.json());
+    user3 = await app
+      .inject({
+        url: `/users/${user3.id}`,
+      })
+      .then((r: any) => r.json());
+    t.ok(
+      !user2.subscribedToUserIds.includes(user1.id) &&
+        !user3.subscribedToUserIds.includes(user1.id),
+      'subscribedToUserIds should be updated'
+    );
+  });
+
+  await t.test('DELETE /users/:id => failure; fake params.id', async (t) => {
+    const res_deleteUser = await app.inject({
+      url: `/users/fakeId`,
+      method: 'DELETE',
+    });
+
+    t.ok(res_deleteUser.statusCode > 300);
+  });
+
+  await t.test(
+    'DELETE /users/:id => success; user with relations',
+    async (t) => {
+      const { body: user1 } = await createUser(app);
+      let { body: user2 } = await createUser(app);
+      const { body: post } = await createPost(app, user1.id);
+      const { body: profile } = await createProfile(app, user1.id, 'basic');
+
+      await app.inject({
+        url: `/users/${user1.id}/subscribeTo`,
+        method: 'POST',
+        payload: {
+          userId: user2.id,
+        },
+      });
+
+      await app
+        .inject({
+          url: `/users/${user1.id}`,
+          method: 'DELETE',
+        })
+        .then((r: any) => r.json());
+
+      const res_findUser1 = await app.inject({
+        url: `/users/${user1.id}`,
+      });
+      t.ok(res_findUser1.statusCode > 300, 'user must be deleted');
+
+      user2 = await app
+        .inject({
+          url: `/users/${user2.id}`,
+        })
+        .then((r: any) => r.json());
+      t.ok(
+        !user2.subscribedToUserIds.includes(user1.id),
+        'no links to the deleted user in subscribedToUserIds'
+      );
+
+      const res_findPost = await app.inject({
+        url: `/posts/${post.id}`,
+      });
+      const res_findProfile = await app.inject({
+        url: `/profiles/${profile.id}`,
+      });
+      t.ok(res_findPost.statusCode > 300, 'post must be deleted');
+      t.ok(res_findProfile.statusCode > 300, 'profile must be deleted');
     }
   );
 });


### PR DESCRIPTION
General Information
=================

- Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md
- How to calculate score: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/score.md
- Deadline: 2023-01-31 03:00 (UTC+3)
- **Score:  360 / 360**



> **Warning**
> **Reviewer**, see the [README.md](https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/feature/graphql-implementation/README.md) before checking.
>
> PLEASE USE [Postman collection](https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/feature/graphql-implementation/RSS%20GraphQL.postman_collection.json) - there are all the needed queries to check this code and PR, with implemented `queries` / `mutations`, as well as `variables`

In addition to Postman collection, mentioned above, here are `queries` / `mutations` for subtasks:

- 2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.

```graphql
query AllEntitiesIds {
    users {id}
    profiles {id}
    posts {id}
    memberTypes {id}
}
```

-  2.2. Get user, profile, post, memberType by id - 4 operations in one query.

```graphql
query EntitiesById($userId: String!, $profileId: String!, $postId: String!, $memberTypeId: String!) {
    user(id: $userId) {id}
    profile(id: $profileId) {id}
    post(id: $postId) {id}
    memberType(id: $memberTypeId) {id}
}
```

variables

```json
{
    "userId": "f898642b-1487-4c20-abf2-7346970851d1",
    "profileId": "9e78f708-c424-4d8d-b444-9a5b04008612",
    "postId": "aa483874-cd34-4cbb-b332-e2327f337fcb",
    "memberTypeId": "basic"
}
```

-  2.3. Get users with their posts, profiles, memberTypes.

```graphql
query UsersWithPostsProfilesMemberTypes {
    users {
        id
        posts {
            id
        }
        profile {
            id
        }
        memberType {
            id
        }
    }
}
```

-  2.4. Get user by id with his posts, profile, memberType.

```graphql
query UserByIdWithPostsProfileMemberType($id: String!) {
    user(id: $id) {
        id
        posts {
            id
        }
        profile {
            id
        }
        memberType {
            id
        }
    }
}
```

variables

```json
{
    "id": "2d7a6d86-d246-44a5-bbbf-6c6686091d45"
}
```

-  2.5. Get users with their `userSubscribedTo`, profile.

```graphql
query UserWithUsersHeIsFollowing {
    users {
        id
        userSubscribedTo {
            id
        }
        profile {
            id
        }
    }
}
```

-  2.6. Get user by id with his `subscribedToUser`, posts.

```graphql
query UserByIdWithSubscribedUsersAndPosts($id: String!) {
    user(id: $id) {
        id
        subscribedToUser {id}
        posts {id}
    }
}
```

variables

```json
{
    "id": "3b25ae9d-2e7d-4f2e-b69b-4e58863309ba"
}
```

- 2.7. Get users with their userSubscribedTo, subscribedToUser (additionally for each user in userSubscribedTo, subscribedToUser add their userSubscribedTo, subscribedToUser).

```graphql
query UserWithNestedFollowersAdFollowingUsers {
    users {
        id
        userSubscribedTo {
            id
            userSubscribedTo {id}
            subscribedToUser {id}
        }
        subscribedToUser  {
            id
            userSubscribedTo {id}
            subscribedToUser {id}
        }
    }
}
```

- 2.8. Create user.

```graphql
mutation CreateUser($user: UserCreateInput!) {
    createUser(user: $user) {
        id
        firstName
        lastName
        email
        subscribedToUserIds
    }
}
```

variables

```json
{
    "user": {
        "firstName": "John",
        "lastName": "Smith",
        "email": "email@example.com"
    }
}
```

-  2.9. Create profile.

```graphql
mutation CreateProfile($profile: ProfileCreateInput!) {
    createProfile(profile: $profile) {
        id
        avatar
        sex
        birthday
        country
        city
        street
        memberTypeId
        userId
    }
}
```

variables

```json
{
    "profile": {
        "avatar": "avatar",
        "sex": "male",
        "birthday": 29834345,
        "country": "USA",
        "city": "New-York",
        "street": "Street",
        "memberTypeId": "basic",
        "userId": "ca78eae8-1a7b-4fa3-970b-892f1491d00c"
    }
}
```

-  2.10. Create post.

```graphql
mutation CreatePost($post: PostCreateInput) {
    createPost(post: $post) {
        id
        title
        content
        userId
    }
}
```

variables

```json
{
    "post": {
        "title": "Title4",
        "content": "content32",
        "userId": "ca78eae8-1a7b-4fa3-970b-892f1491d00c"
    }
}
```

- 2.11. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.

For all the input data - `input` types are used, for example: 

https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/ba36988d3747203a6cf8bfc5d9f7078792bdb070/src/routes/graphql/user/userCreateInput.ts#L3-L10

-  2.12. Update user.

```graphql
mutation UpdateUser($user: UserUpdateInput!, $userId: String!) {
    updateUser(userId: $userId, user: $user) {
        id
        firstName
        lastName
        email
        subscribedToUserIds
    }
}
```

variables

```json
{
    "userId": "6fe4536e-b9a2-4162-879d-aa748c5b9850",
    "user": {
        "firstName": "Nick"
    }
}
```

-  2.13. Update profile.

```graphql
mutation UpdateProfile($profile: ProfileUpdateInput!, $profileId: String!) {
    updateProfile(profileId: $profileId, profile: $profile) {
        id
        country
    }
}
```

variables

```json
{
    "profileId": "6b2872f2-ad4c-43bc-b98c-9506d92a35a9",
    "profile": {
        "country": "BY"
    }
}
```

-  2.14. Update post.

```graphql
mutation UpdatePost($post: PostUpdateInput!, $postId: String!) {
    updatePost(postId: $postId, post: $post) {
        id
        title
        content
        userId
    }
}
```

variables

```json
{
    "postId": "348a4eb4-0722-42bc-9e37-08c6bd2261d8",
    "post": {
        "title": "BY fffff",
        "content": "new content"
    }
}
```

-  2.15. Update memberType.

```graphql
mutation UpdateMemberType($memberType: MemberTypeUpdateInput!, $memberTypeId: String!) {
    updateMemberType(memberTypeId: $memberTypeId, memberType: $memberType) {
        id
        discount
        monthPostsLimit
    }
}
```

variables

```json
{
    "memberTypeId": "business",
    "memberType": {
        "discount": 54
    }
}
```

- 2.16. Subscribe to

```graphql
mutation UserSubscribeTo($payload: UserSubscribeToInput!) {
    subscribeUserTo(payload: $payload) {
        id
        firstName
        lastName
        email
        subscribedToUserIds
        userSubscribedTo {id}
    }
}
```

variables

```json
{
    "payload": {
        "currentUserId": "ca78eae8-1a7b-4fa3-970b-892f1491d00c",
        "subscribeToUserId": "409a88a7-4010-4ca7-ad66-76f4521eb519"
    }
}
```

-  2.16. Unsubscribe from

```graphql
mutation UnsubscribeUserFrom($payload: UserUnsubscribeFromInput!) {
    unsubscribeUserFrom(payload: $payload) {
        id
        firstName
        lastName
        email
        subscribedToUserIds
        userSubscribedTo {id}
    }
}
```

variables

```json
{
    "payload": {
        "currentUserId": "44acec7c-b3a5-43e3-94d6-839eba2e3522",
        "unsubscribeFromUserId": "8a4e7e34-f254-404b-9966-a20bb432ec65"
    }
}
```

- 2.17. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.

For all the input data - `input` types are used, for example: 

https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/ba36988d3747203a6cf8bfc5d9f7078792bdb070/src/routes/graphql/user/userUpdateInput.ts#L3-L10

- Task 3

>  3.1. List where the dataloader was used with links to the lines of code (creation in gql context and call in resolver).

https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/95b9b4b60e9db7b188a06ea679d9d3503a3ad342/src/routes/graphql/index.ts#L91-L101

and calls in resolvers:

https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/95b9b4b60e9db7b188a06ea679d9d3503a3ad342/src/routes/graphql/user/userType.ts#L19-L21

and all the other resolvers in similar cases

DataLoaders themselves are implemented here: https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/95b9b4b60e9db7b188a06ea679d9d3503a3ad342/src/routes/graphql/createDataLoaders.ts

- Task 4 - `graphql-depth-limit`

Limit level is 6.

```graphql
query UserWithDepthOverflow {
    users {
        id
        subscribedToUser {
            userSubscribedTo {
                subscribedToUser {
                    userSubscribedTo {
                        subscribedToUser {
                            userSubscribedTo {
                                id
                            }
                        }
                    }
                }
            }
        }
    }
}
```

> 4.1. Provide a link to the line of code where it was used.

https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/95b9b4b60e9db7b188a06ea679d9d3503a3ad342/src/routes/graphql/index.ts#L83-L88

and

https://github.com/maks-rafalko/nodejs-rss-task-graphql/blob/95b9b4b60e9db7b188a06ea679d9d3503a3ad342/src/routes/graphql/validateQuery.ts#L18-L20

Self-review
=========

Self-review rating - 360 points 

### Basic Scope
- [x] **+72** Task 1: restful endpoints.
- [x] **+72** Subtasks 2.1-2.7: get gql queries.
- [x] **+54** Subtasks 2.8-2.11: create gql queries.
- [x] **+54** Subtasks 2.12-2.17: update gql queries.
- [x] **+88** Task 3: solve `n+1` graphql problem.
- [x] **+20** Task 4: limit the complexity of the graphql queries.

### Forfeits
- [ ] **-30% of max task score** Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
- [ ] **-60% of max task score** Samples of POST body for gql requests were not provided for those subtasks that were declared to be completed.
- [ ] **-100% of max task score** Tests have been modified.
- [ ] **-20** No separate development branch
- [ ] **-20** No Pull Request
- [ ] **-10** Pull Request description is incorrect
- [ ] **-20** Less than 3 commits in the development branch, not including commits that make changes only to `Readme.md` or similar files (`tsconfig.json`, `.gitignore`, `.prettierrc.json`, etc.)